### PR TITLE
Add PHP front-end (cccc-php / cccc-php-cli)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +110,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +149,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "castaway"
@@ -179,6 +224,26 @@ dependencies = [
  "assert_cmd",
  "cccc-cli",
  "cccc-go",
+ "predicates",
+ "serde_json",
+]
+
+[[package]]
+name = "cccc-php"
+version = "0.3.0"
+dependencies = [
+ "cccc-core",
+ "php-ast",
+ "php-rs-parser",
+]
+
+[[package]]
+name = "cccc-php-cli"
+version = "0.3.0"
+dependencies = [
+ "assert_cmd",
+ "cccc-cli",
+ "cccc-php",
  "predicates",
  "serde_json",
 ]
@@ -319,6 +384,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +407,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "globset"
@@ -390,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +517,45 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "nonmax"
@@ -466,6 +598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,7 +630,7 @@ dependencies = [
  "textwrap",
  "thiserror",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -743,6 +884,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "php-ast"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe285cbc896a2078199f16cd30698d50e15f7693c466877fbea5b8b3b959752"
+dependencies = [
+ "bumpalo",
+ "serde",
+]
+
+[[package]]
+name = "php-lexer"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4531e03c81c0e29096a9476d329d16877e75641acfab52a5e90b5d0e5aa27b4c"
+dependencies = [
+ "memchr",
+ "php-ast",
+]
+
+[[package]]
+name = "php-rs-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0433a922a1faf30b47f5c8450480caeeef766baa76ce856d09f4dd53c2a8ea10"
+dependencies = [
+ "bumpalo",
+ "memchr",
+ "miette",
+ "php-ast",
+ "php-lexer",
+ "phpdoc-parser",
+ "thiserror",
+]
+
+[[package]]
+name = "phpdoc-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d3342540d6d5dfa2b652788f70a3b8840ae12653b15ef07261c4c70de4b27f9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,10 +1025,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -961,6 +1165,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1194,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -985,7 +1220,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1073,6 +1308,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ members = [
     "crates/cccc-rs-cli",
     "crates/cccc-go",
     "crates/cccc-go-cli",
+    "crates/cccc-php",
+    "crates/cccc-php-cli",
 ]
 resolver = "2"
 
@@ -25,6 +27,7 @@ cccc-cli = { path = "crates/cccc-cli", version = "0.3.0" }
 cccc-es = { path = "crates/cccc-es", version = "0.3.0" }
 cccc-rs = { path = "crates/cccc-rs", version = "0.3.0" }
 cccc-go = { path = "crates/cccc-go", version = "0.3.0" }
+cccc-php = { path = "crates/cccc-php", version = "0.3.0" }
 serde = { version = "1", features = ["derive"] }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # cccc - A tool/library for measurement of **C**ognitive **C**omplexity and **C**yclomatic **C**omplexity
 
 - A fast CLI that measures **Cognitive Complexity** (SonarSource / G. Ann Campbell)
-  and **Cyclomatic Complexity** (McCabe). Written in Rust; three language front-ends
+  and **Cyclomatic Complexity** (McCabe). Written in Rust; four language front-ends
   ship today, all sharing the same engine, CLI, flags, and output format:
   - **`cccc-es`** — TypeScript / JavaScript, via the [oxc](https://oxc.rs) parser.
     Supports `.ts`, `.tsx`, `.js`, `.jsx`, `.mts`, `.cts`, `.mjs`, `.cjs`.
   - **`cccc-rs`** — Rust, via the [syn](https://docs.rs/syn) parser. Supports `.rs`.
   - **`cccc-go`** — Go, via the [gosyn](https://docs.rs/gosyn) parser. Supports `.go`.
+  - **`cccc-php`** — PHP, via the [php-rs-parser](https://docs.rs/php-rs-parser)
+    parser. Supports `.php`.
 - A Rust library for calculating cognitive and cyclomatic complexity in a language-agnostic way
 
 ## Workspace layout
@@ -24,6 +26,8 @@ library and extended to other languages:
 | [`cccc-rs-cli`](crates/cccc-rs-cli) | The **`cccc-rs`** binary: a thin shell that wires the `cccc-rs` adapter into the shared `cccc-cli` runner. |
 | [`cccc-go`](crates/cccc-go) | Go adapter **library**: lowers the [gosyn](https://docs.rs/gosyn) AST into `cccc-core`'s IR. Depends only on `cccc-core` + gosyn — **no CLI dependencies**. |
 | [`cccc-go-cli`](crates/cccc-go-cli) | The **`cccc-go`** binary: a thin shell that wires the `cccc-go` adapter into the shared `cccc-cli` runner. |
+| [`cccc-php`](crates/cccc-php) | PHP adapter **library**: lowers the [php-rs-parser](https://docs.rs/php-rs-parser) AST into `cccc-core`'s IR. Depends only on `cccc-core` + php-rs-parser / php-ast — **no CLI dependencies**. |
+| [`cccc-php-cli`](crates/cccc-php-cli) | The **`cccc-php`** binary: a thin shell that wires the `cccc-php` adapter into the shared `cccc-cli` runner. |
 
 The adapter and the binary are separate crates so that a library consumer who
 only wants the metrics pulls in just `cccc-es` (+ `cccc-core` + oxc), never clap
@@ -34,8 +38,8 @@ To support another language: (1) add an adapter crate that lowers its AST into
 binary crate whose `main` calls
 `cccc_cli::run(env!("CARGO_BIN_NAME"), env!("CARGO_PKG_VERSION"), analyze_source, DEFAULT_EXTS)`
 — no need to reimplement either the metrics or the CLI. `cccc-es` (oxc),
-`cccc-rs` (syn), and `cccc-go` (gosyn) are the reference adapters: same shape,
-different parser.
+`cccc-rs` (syn), `cccc-go` (gosyn), and `cccc-php` (php-rs-parser) are the
+reference adapters: same shape, different parser.
 
 **See [docs/ADDING_A_LANGUAGE.md](docs/ADDING_A_LANGUAGE.md) for the full
 step-by-step guide**, including the IR-node reference table, the
@@ -56,7 +60,7 @@ assert_eq!(report.functions[0].cognitive, 1);  // one `if`
 
 ```sh
 cargo build --release
-# binaries at ./target/release/cccc-es, ./target/release/cccc-rs, and ./target/release/cccc-go
+# binaries at ./target/release/cccc-es, ./target/release/cccc-rs, ./target/release/cccc-go, and ./target/release/cccc-php
 ```
 
 ## Usage
@@ -65,11 +69,12 @@ cargo build --release
 cccc-es <paths...> [options]   # TypeScript / JavaScript
 cccc-rs <paths...> [options]   # Rust
 cccc-go <paths...> [options]   # Go
+cccc-php <paths...> [options]  # PHP
 ```
 
 All front-ends take the **same flags and produce the same output format** — the
-examples below use `cccc-es`, but `cccc-rs` and `cccc-go` behave identically on
-`.rs` and `.go` files respectively.
+examples below use `cccc-es`, but `cccc-rs`, `cccc-go`, and `cccc-php` behave
+identically on `.rs`, `.go`, and `.php` files respectively.
 
 Output is **JSON by default**. Pass one or more files or directories;
 directories are walked recursively (respecting `.gitignore`, always skipping
@@ -239,3 +244,11 @@ For **Go** (`cccc-go`): top-level functions / methods / function literals
 non-decision arm), labelled `break`/`continue`/`goto`, and `&&`/`||` map to the
 corresponding nodes. Go has no ternary and no `try`/`catch` (errors are returned
 values), so those simply don't occur.
+
+For **PHP** (`cccc-php`): functions / methods / closures / `fn` arrow functions /
+property hooks are the function-like units; `if`/`elseif`/`else`, `while`/
+`do`-`while`/`for`/`foreach`, `switch` and the `match` expression (a `default`
+arm is the non-decision case), `catch` clauses, multi-level `break N`/
+`continue N` and `goto`, the ternary `?:`, and `&&`/`and`/`||`/`or`/`??` map to
+the corresponding nodes. `&&` and `and` (likewise `||` and `or`) are the same
+normalized operator; `??` folds as a coalescing run.

--- a/crates/cccc-php-cli/Cargo.toml
+++ b/crates/cccc-php-cli/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "cccc-php-cli"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "The cccc-php binary: PHP cognitive/cyclomatic complexity CLI"
+
+[[bin]]
+name = "cccc-php"
+path = "src/main.rs"
+
+[dependencies]
+cccc-cli = { workspace = true }
+cccc-php = { workspace = true }
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+serde_json = "1"

--- a/crates/cccc-php-cli/src/main.rs
+++ b/crates/cccc-php-cli/src/main.rs
@@ -1,0 +1,13 @@
+//! The `cccc-php` binary: PHP front-end.
+//!
+//! All CLI behaviour lives in `cccc_cli`; this binary only wires in the PHP
+//! adapter (`analyze_source`) and its default file extensions.
+
+fn main() {
+    std::process::exit(cccc_cli::run(
+        env!("CARGO_BIN_NAME"),
+        env!("CARGO_PKG_VERSION"),
+        cccc_php::analyze_source,
+        cccc_php::DEFAULT_EXTS,
+    ));
+}

--- a/crates/cccc-php-cli/tests/cli.rs
+++ b/crates/cccc-php-cli/tests/cli.rs
@@ -1,0 +1,214 @@
+use assert_cmd::Command;
+
+#[test]
+fn version_reports_binary_name() {
+    Command::cargo_bin("cccc-php")
+        .unwrap()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicates::str::starts_with("cccc-php "));
+}
+
+#[test]
+fn nonexistent_path_is_an_error() {
+    Command::cargo_bin("cccc-php")
+        .unwrap()
+        .arg("/no/such/path-xyz")
+        .assert()
+        .failure()
+        .code(2);
+}
+
+#[test]
+fn existing_dir_with_no_matches_is_ok() {
+    // A real directory containing nothing analyzable is an empty, successful run
+    // — distinct from a path that doesn't exist.
+    let dir = std::env::temp_dir().join("cccc_php_empty_match_test");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("readme.md"), "# not analyzed").unwrap();
+    Command::cargo_bin("cccc-php")
+        .unwrap()
+        .arg(&dir)
+        .assert()
+        .success();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn outputs_json_by_default() {
+    let out = Command::cargo_bin("cccc-php")
+        .unwrap()
+        .arg("tests/fixtures/sample.php")
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let file = &v["files"][0];
+    assert_eq!(file["path"], "tests/fixtures/sample.php");
+    let funcs = file["functions"].as_array().unwrap();
+    let sop = funcs.iter().find(|f| f["name"] == "sumOfPrimes").unwrap();
+    assert_eq!(sop["cognitive"], 7);
+    assert_eq!(sop["cyclomatic"], 4);
+}
+
+#[test]
+fn jobs_option_produces_same_output() {
+    // The result must be independent of the worker count.
+    let single = Command::cargo_bin("cccc-php")
+        .unwrap()
+        .args(["--jobs", "1", "tests/fixtures/sample.php"])
+        .assert()
+        .success();
+    let many = Command::cargo_bin("cccc-php")
+        .unwrap()
+        .args(["-j", "4", "tests/fixtures/sample.php"])
+        .assert()
+        .success();
+    assert_eq!(
+        single.get_output().stdout,
+        many.get_output().stdout,
+        "output must not depend on --jobs"
+    );
+}
+
+#[test]
+fn jobs_zero_is_rejected() {
+    Command::cargo_bin("cccc-php")
+        .unwrap()
+        .args(["--jobs", "0", "tests/fixtures/sample.php"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn includes_project_summary() {
+    let out = Command::cargo_bin("cccc-php")
+        .unwrap()
+        .arg("tests/fixtures/sample.php")
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let s = &v["summary"];
+    assert_eq!(s["file_count"], 1);
+    // sample.php has sumOfPrimes, getWords, classify.
+    assert_eq!(s["function_count"], 3);
+    assert_eq!(s["cognitive"]["sum"], 10);
+    assert_eq!(s["cognitive"]["max"], 7);
+    assert!(s["cognitive"]["median"].is_number());
+    assert!(s["cyclomatic"]["p95"].is_number());
+}
+
+#[test]
+fn top_cognitive_returns_flat_ranking() {
+    let out = Command::cargo_bin("cccc-php")
+        .unwrap()
+        .args(["--top-cognitive", "2", "tests/fixtures/sample.php"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert!(v.get("files").is_none(), "top mode must not emit files");
+    assert_eq!(v["metric"], "cognitive");
+    let top = v["top"].as_array().unwrap();
+    assert_eq!(top.len(), 2);
+    // sample.php: sumOfPrimes(7) > classify(2) > getWords(1).
+    assert_eq!(top[0]["name"], "sumOfPrimes");
+    assert_eq!(top[0]["cognitive"], 7);
+    assert_eq!(top[0]["path"], "tests/fixtures/sample.php");
+    assert_eq!(top[1]["name"], "classify");
+    // summary still reflects the full population (3 functions).
+    assert_eq!(v["summary"]["function_count"], 3);
+}
+
+#[test]
+fn top_cyclomatic_orders_by_cyclomatic() {
+    let out = Command::cargo_bin("cccc-php")
+        .unwrap()
+        .args(["--top-cyclomatic", "1", "tests/fixtures/sample.php"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(v["metric"], "cyclomatic");
+    // sumOfPrimes has the highest cyclomatic (4).
+    assert_eq!(v["top"][0]["name"], "sumOfPrimes");
+    assert_eq!(v["top"][0]["cyclomatic"], 4);
+}
+
+#[test]
+fn top_flags_are_mutually_exclusive() {
+    Command::cargo_bin("cccc-php")
+        .unwrap()
+        .args([
+            "--top-cognitive",
+            "1",
+            "--top-cyclomatic",
+            "1",
+            "tests/fixtures/sample.php",
+        ])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn exclude_glob_drops_matching_files() {
+    // `--exclude` lives in the shared cccc-cli crate; this smoke test confirms
+    // the cccc-php front-end wires it through. Excluding `*Test.php` by file name
+    // must leave only the non-test file.
+    let dir = std::env::temp_dir().join("cccc_php_exclude_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(dir.join("src/App.php"), "<?php\nfunction a() { return 1; }").unwrap();
+    std::fs::write(
+        dir.join("src/AppTest.php"),
+        "<?php\nfunction b() { return 2; }",
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("cccc-php")
+        .unwrap()
+        .args(["--exclude", "*Test.php"])
+        .arg(&dir)
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let files = v["files"].as_array().unwrap();
+    assert_eq!(files.len(), 1, "the *Test.php file must be excluded");
+    assert!(files[0]["path"].as_str().unwrap().ends_with("App.php"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn max_cognitive_threshold_fails() {
+    // sumOfPrimes has cognitive 7, so a max of 5 must fail (exit 1).
+    Command::cargo_bin("cccc-php")
+        .unwrap()
+        .args(["--max-cognitive", "5", "tests/fixtures/sample.php"])
+        .assert()
+        .failure()
+        .code(1);
+}
+
+#[test]
+fn max_cognitive_threshold_passes_when_under() {
+    Command::cargo_bin("cccc-php")
+        .unwrap()
+        .args(["--max-cognitive", "100", "tests/fixtures/sample.php"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn table_output_renders() {
+    Command::cargo_bin("cccc-php")
+        .unwrap()
+        .args(["--table", "tests/fixtures/sample.php"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("sumOfPrimes"))
+        .stdout(predicates::str::contains("file total"))
+        .stdout(predicates::str::contains("summary"));
+}

--- a/crates/cccc-php-cli/tests/fixtures/sample.php
+++ b/crates/cccc-php-cli/tests/fixtures/sample.php
@@ -1,0 +1,37 @@
+<?php
+// Fixture with known complexity values, used by integration tests.
+
+// Cognitive: for(+1) + nested for(+2) + nested if(+3) + multi-level continue(+1) = 7
+// Cyclomatic: base 1 + for + for + if = 4
+function sumOfPrimes($max) {
+    $total = 0;
+    for ($i = 2; $i <= $max; $i++) {
+        for ($j = 2; $j < $i; $j++) {
+            if ($i % $j == 0) {
+                continue 2;
+            }
+        }
+        $total += $i;
+    }
+    return $total;
+}
+
+// Cognitive: switch(+1) = 1 ; Cyclomatic: base 1 + 2 non-default cases = 3
+function getWords($n) {
+    switch ($n) {
+        case 1:
+            return "one";
+        case 2:
+            return "a couple";
+        default:
+            return "lots";
+    }
+}
+
+// Cognitive: if(+1) + &&(+1) = 2 ; Cyclomatic: base 1 + if + && = 3
+function classify($a, $b) {
+    if ($a && $b) {
+        return "both";
+    }
+    return "not";
+}

--- a/crates/cccc-php/Cargo.toml
+++ b/crates/cccc-php/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cccc-php"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "PHP (php-rs-parser) adapter that lowers source into the cccc-core complexity IR"
+
+[dependencies]
+cccc-core = { workspace = true }
+# Pure-Rust, fault-tolerant PHP parser (PHP 7.4–8.5), so there is no C toolchain
+# and cross-compilation stays clean. `php-ast` provides the lifetime-free owned
+# AST plus the `OwnedVisitor` full-traversal trait we drive lowering from.
+php-rs-parser = "0.18.1"
+php-ast = "0.18.1"

--- a/crates/cccc-php/src/lib.rs
+++ b/crates/cccc-php/src/lib.rs
@@ -281,6 +281,11 @@ impl Builder {
                 }
             }
             StmtKind::Namespace(n) => {
+                // Only the braced form `namespace Foo { … }` nests its members
+                // here. The semicolon form `namespace Foo;` is `Simple` and
+                // carries no body — its declarations are top-level siblings in
+                // `Program.stmts`, already visited by the module-level loop — so
+                // there is nothing to descend into for that variant.
                 if let NamespaceBody::Braced(block) = &n.body {
                     for s in block.stmts.iter() {
                         let _ = self.visit_stmt(s);
@@ -943,6 +948,48 @@ mod tests {
         assert_eq!(find(&analyze(src).functions, "m").unwrap().kind, "method");
         // A closure passed as a constructor argument is still reached.
         assert_eq!(cognitive_of(src, "<arrow>"), 1); // &&
+    }
+
+    #[test]
+    fn namespace_declarations_are_lowered_in_both_forms() {
+        // Semicolon form: `namespace Foo;` is `Simple`, so its declarations are
+        // top-level siblings reached by the module-level loop.
+        let semicolon = r#"<?php
+            namespace Foo;
+            function f($x) {
+                if ($x) {
+                    return 1;
+                }
+                return 0;
+            }
+            class C {
+                public function m($y) {
+                    foreach ($y as $i) {
+                        if ($i) {
+                            return $i;
+                        }
+                    }
+                    return null;
+                }
+            }
+        "#;
+        assert_eq!(cognitive_of(semicolon, "f"), 1); // if
+        assert_eq!(cognitive_of(semicolon, "m"), 3); // foreach + nested if
+        assert_eq!(analyze(semicolon).functions.len(), 2);
+
+        // Braced form: `namespace Foo { … }` nests its members in a block.
+        let braced = r#"<?php
+            namespace Foo {
+                function g($x) {
+                    if ($x) {
+                        return 1;
+                    }
+                    return 0;
+                }
+            }
+        "#;
+        assert_eq!(cognitive_of(braced, "g"), 1);
+        assert_eq!(analyze(braced).functions.len(), 1);
     }
 
     #[test]

--- a/crates/cccc-php/src/lib.rs
+++ b/crates/cccc-php/src/lib.rs
@@ -1,0 +1,934 @@
+//! PHP adapter: parses source with [php-rs-parser](https://docs.rs/php-rs-parser)
+//! and lowers the AST into the language-agnostic [`cccc_core::ir`].
+//!
+//! This is a pure library — it depends only on `cccc-core` and the pure-Rust
+//! `php-rs-parser` / `php-ast` crates (no C toolchain, so cross-compilation stays
+//! clean), with no CLI machinery. The `cccc-php` binary lives in the separate
+//! `cccc-php-cli` crate, which combines [`analyze_source`]/[`DEFAULT_EXTS`] with
+//! the shared `cccc-cli` runner.
+//!
+//! This crate contains **no scoring logic** — it only recognizes the constructs
+//! the engine cares about (functions/methods/closures/arrows/property-hooks,
+//! `if`/`elseif`/`else`, `switch`/`match`, loops, `try`/`catch`, multi-level
+//! `break`/`continue`/`goto`, `&&`/`||`/`and`/`or`/`??` sequences, calls) and
+//! emits the matching IR nodes. All complexity rules live in
+//! [`cccc_core::engine`].
+//!
+//! ## Lowering strategy
+//!
+//! `php-ast` ships an [`OwnedVisitor`] trait whose default `walk_owned_*`
+//! methods recurse into *every* child. We drive lowering from it so no construct
+//! in an unexpected position (a closure in a default argument, an operator inside
+//! an index) is silently missed: we override [`OwnedVisitor::visit_stmt`] and
+//! [`OwnedVisitor::visit_expr`], handle the structural nodes explicitly (building
+//! the IR with a stack of "collectors", see [`Builder::collect`]), and for every
+//! other node fall through to the parser's complete default walk. The owned
+//! (lifetime-free) AST lets us avoid juggling the parser's arena.
+//!
+//! ## PHP-to-IR mapping notes
+//!
+//! - `function` / method / closure / `fn` arrow / property hook →
+//!   [`Node::Function`] (`"function"` / `"method"` / `"closure"` / `"arrow"` /
+//!   `"hook"`). A closure/arrow bound to a variable (`$f = fn() => …`) borrows
+//!   that name.
+//! - `if` / `elseif` / `else` → [`Node::Branch`] (chaining `elseif` as a nested
+//!   `Branch` so it scores flat).
+//! - ternary `?:` (and the short `?:`) → [`Node::Conditional`]; `??` →
+//!   [`Node::Logical`] with [`LogicalOp::Coalesce`].
+//! - `while` / `do`-`while` / `for` / `foreach` → [`Node::Loop`].
+//! - `switch` and the `match` expression → [`Node::Switch`]; the `default` arm is
+//!   not a cyclomatic decision point.
+//! - `catch` clauses → [`Node::Catch`] (the `try` and `finally` bodies score at
+//!   the surrounding level).
+//! - `goto` and multi-level `break N` / `continue N` (`N >= 2`) → labelled
+//!   [`Node::Jump`]; plain `break` / `continue` score flat.
+//! - `&&` / `and` / `||` / `or` / `??` runs → folded [`Node::Logical`] (one node
+//!   per like-operator run).
+//! - calls (`f(..)`, `$o->m(..)`, `C::m(..)`) → [`Node::Call`] for recursion
+//!   detection.
+
+use std::path::Path;
+
+use cccc_core::engine;
+use cccc_core::ir::{LogicalOp, Node, SwitchCase};
+use cccc_core::report::FileReport;
+use php_ast::ast::BinaryOp;
+use php_ast::owned::visitor::{OwnedVisitor, walk_owned_expr, walk_owned_stmt};
+use php_ast::owned::{
+    ClassDecl, ClassMemberKind, EnumMemberKind, Expr, ExprKind, Ident, NamespaceBody, PropertyHook,
+    PropertyHookBody, Stmt, StmtKind,
+};
+
+/// File extensions analyzed by default (when `--ext` is not given).
+pub const DEFAULT_EXTS: &[&str] = &["php"];
+
+/// Parse `source` and produce its [`FileReport`], scoring via the core engine.
+/// This is the convenience entry point used by the CLI; for the raw IR (e.g. to
+/// feed a different consumer) use [`to_ir`].
+pub fn analyze_source(path: &Path, source: &str) -> FileReport {
+    let (nodes, parse_errors) = to_ir(path, source);
+    engine::analyze(&path.display().to_string(), &nodes, parse_errors)
+}
+
+/// Parse `source` and lower it to the complexity IR, returning the module-level
+/// nodes plus any parser error messages. `php-rs-parser` is fault-tolerant: it
+/// always yields a (possibly partial) AST, so we lower whatever it recovered and
+/// surface the diagnostics alongside.
+pub fn to_ir(_path: &Path, source: &str) -> (Vec<Node>, Vec<String>) {
+    let result = php_rs_parser::parse(source);
+    let mut builder = Builder::new(source);
+    for stmt in result.program.stmts.iter() {
+        let _ = builder.visit_stmt(stmt);
+    }
+    let parse_errors = result.errors.iter().map(|e| e.to_string()).collect();
+    (builder.finish(), parse_errors)
+}
+
+/// Assembles the IR tree while `php-ast`'s [`OwnedVisitor`] drives a complete
+/// AST traversal.
+struct Builder {
+    /// Stack of node collectors. `stack.last_mut()` receives emitted nodes;
+    /// structural nodes push a fresh collector for their body, then pop it.
+    stack: Vec<Vec<Node>>,
+    /// Byte offset of the start of each 1-based line, for offset → line lookup.
+    line_starts: Vec<u32>,
+    /// Name captured from `$x = fn()…` / `$x = function()…` to label the next
+    /// closure or arrow function.
+    pending_name: Option<String>,
+}
+
+impl Builder {
+    fn new(source: &str) -> Self {
+        // line_starts[0] = 0 (line 1); each '\n' begins the next line.
+        let mut line_starts = vec![0u32];
+        for (i, b) in source.bytes().enumerate() {
+            if b == b'\n' {
+                line_starts.push((i + 1) as u32);
+            }
+        }
+        Self {
+            stack: vec![Vec::new()], // module-level collector
+            line_starts,
+            pending_name: None,
+        }
+    }
+
+    /// 1-based line containing byte offset `pos`.
+    fn line(&self, pos: u32) -> u32 {
+        self.line_starts.partition_point(|&start| start <= pos) as u32
+    }
+
+    /// The module-level node list (the single remaining collector).
+    fn finish(mut self) -> Vec<Node> {
+        self.stack.pop().expect("module collector")
+    }
+
+    /// Append a node to the current collector.
+    fn emit(&mut self, node: Node) {
+        self.stack.last_mut().expect("collector").push(node);
+    }
+
+    /// Run `f` against a fresh collector and return the nodes it gathered.
+    fn collect<F: FnOnce(&mut Self)>(&mut self, f: F) -> Vec<Node> {
+        self.stack.push(Vec::new());
+        f(self);
+        self.stack.pop().expect("collector")
+    }
+
+    /// Emit a `Function` whose body is whatever `walk` gathers in a sub-traversal.
+    fn emit_function<F: FnOnce(&mut Self)>(
+        &mut self,
+        name: String,
+        kind: &'static str,
+        line: u32,
+        walk: F,
+    ) {
+        let body = self.collect(walk);
+        self.emit(Node::Function {
+            name,
+            kind: kind.to_string(),
+            line,
+            body,
+        });
+    }
+
+    // ---- statements -------------------------------------------------------
+
+    fn lower_stmt(&mut self, stmt: &Stmt) {
+        match &stmt.kind {
+            StmtKind::Function(f) => {
+                let line = self.line(stmt.span.start);
+                self.emit_function(ident_name(&f.name, "<function>"), "function", line, |b| {
+                    for s in f.body.stmts.iter() {
+                        let _ = b.visit_stmt(s);
+                    }
+                });
+            }
+            StmtKind::If(i) => {
+                let test = self.collect(|b| {
+                    let _ = b.visit_expr(&i.condition);
+                });
+                let then = self.collect(|b| {
+                    let _ = b.visit_stmt(&i.then_branch);
+                });
+                let alternate = self.lower_else(&i.elseif_branches, &i.else_branch);
+                self.emit(Node::Branch {
+                    test,
+                    then,
+                    alternate,
+                });
+            }
+            StmtKind::While(w) => {
+                let body = self.collect(|b| {
+                    let _ = b.visit_expr(&w.condition);
+                    let _ = b.visit_stmt(&w.body);
+                });
+                self.emit(Node::Loop { body });
+            }
+            StmtKind::DoWhile(d) => {
+                let body = self.collect(|b| {
+                    let _ = b.visit_stmt(&d.body);
+                    let _ = b.visit_expr(&d.condition);
+                });
+                self.emit(Node::Loop { body });
+            }
+            StmtKind::For(f) => {
+                let body = self.collect(|b| {
+                    for e in f
+                        .init
+                        .iter()
+                        .chain(f.condition.iter())
+                        .chain(f.update.iter())
+                    {
+                        let _ = b.visit_expr(e);
+                    }
+                    let _ = b.visit_stmt(&f.body);
+                });
+                self.emit(Node::Loop { body });
+            }
+            StmtKind::Foreach(f) => {
+                let body = self.collect(|b| {
+                    let _ = b.visit_expr(&f.expr);
+                    if let Some(key) = &f.key {
+                        let _ = b.visit_expr(key);
+                    }
+                    let _ = b.visit_expr(&f.value);
+                    let _ = b.visit_stmt(&f.body);
+                });
+                self.emit(Node::Loop { body });
+            }
+            StmtKind::Switch(sw) => {
+                // The subject runs at the switch's own level, before its cases.
+                let _ = self.visit_expr(&sw.expr);
+                let mut cases = Vec::new();
+                for case in sw.body.cases.iter() {
+                    let body = self.collect(|b| {
+                        if let Some(value) = &case.value {
+                            let _ = b.visit_expr(value);
+                        }
+                        for s in case.body.iter() {
+                            let _ = b.visit_stmt(s);
+                        }
+                    });
+                    cases.push(SwitchCase {
+                        is_default: case.value.is_none(),
+                        body,
+                    });
+                }
+                self.emit(Node::Switch { cases });
+            }
+            StmtKind::TryCatch(t) => {
+                for s in t.body.stmts.iter() {
+                    let _ = self.visit_stmt(s);
+                }
+                for catch in t.catches.iter() {
+                    let body = self.collect(|b| {
+                        for s in catch.body.stmts.iter() {
+                            let _ = b.visit_stmt(s);
+                        }
+                    });
+                    self.emit(Node::Catch { body });
+                }
+                if let Some(finally) = &t.finally {
+                    for s in finally.stmts.iter() {
+                        let _ = self.visit_stmt(s);
+                    }
+                }
+            }
+            StmtKind::Break(level) => self.emit(Node::Jump {
+                labeled: is_multi_level(level),
+            }),
+            StmtKind::Continue(level) => self.emit(Node::Jump {
+                labeled: is_multi_level(level),
+            }),
+            // `goto` always names a label, so it scores one flat point.
+            StmtKind::Goto(_) => self.emit(Node::Jump { labeled: true }),
+            StmtKind::Class(c) => self.lower_class(c),
+            StmtKind::Interface(i) => self.lower_members(&i.body.members),
+            StmtKind::Trait(t) => self.lower_members(&t.body.members),
+            StmtKind::Enum(e) => {
+                for member in e.body.members.iter() {
+                    if let EnumMemberKind::Method(m) = &member.kind
+                        && let Some(body) = &m.body
+                    {
+                        let line = self.line(member.span.start);
+                        self.emit_function(ident_name(&m.name, "<method>"), "method", line, |b| {
+                            for s in body.stmts.iter() {
+                                let _ = b.visit_stmt(s);
+                            }
+                        });
+                    }
+                }
+            }
+            StmtKind::Namespace(n) => {
+                if let NamespaceBody::Braced(block) = &n.body {
+                    for s in block.stmts.iter() {
+                        let _ = self.visit_stmt(s);
+                    }
+                }
+            }
+            StmtKind::Declare(d) => {
+                if let Some(body) = &d.body {
+                    let _ = self.visit_stmt(body);
+                }
+            }
+            // Everything else (expression statements, echo, return, throw, …)
+            // carries no structural score of its own; the parser's default walk
+            // recurses into its sub-expressions so nested calls / closures /
+            // operators are still reached.
+            _ => {
+                let _ = walk_owned_stmt(self, stmt);
+            }
+        }
+    }
+
+    /// Fold an `elseif`/`else` tail into the outer branch's `alternate`: each
+    /// `elseif` is a nested `Branch` (so it scores flat), a plain `else` is a
+    /// `Group`.
+    fn lower_else(
+        &mut self,
+        elseifs: &[php_ast::owned::ElseIfBranch],
+        else_branch: &Option<Box<Stmt>>,
+    ) -> Option<Box<Node>> {
+        if let Some((first, rest)) = elseifs.split_first() {
+            let test = self.collect(|b| {
+                let _ = b.visit_expr(&first.condition);
+            });
+            let then = self.collect(|b| {
+                let _ = b.visit_stmt(&first.body);
+            });
+            let alternate = self.lower_else(rest, else_branch);
+            Some(Box::new(Node::Branch {
+                test,
+                then,
+                alternate,
+            }))
+        } else {
+            else_branch.as_ref().map(|else_stmt| {
+                Box::new(Node::Group(self.collect(|b| {
+                    let _ = b.visit_stmt(else_stmt);
+                })))
+            })
+        }
+    }
+
+    fn lower_class(&mut self, class: &ClassDecl) {
+        self.lower_members(&class.body.members);
+    }
+
+    fn lower_members(&mut self, members: &[php_ast::owned::ClassMember]) {
+        for member in members {
+            match &member.kind {
+                ClassMemberKind::Method(m) => {
+                    // A bodyless method (abstract / interface) is not a
+                    // measurable unit, so don't report it as a function.
+                    if let Some(body) = &m.body {
+                        let line = self.line(member.span.start);
+                        self.emit_function(ident_name(&m.name, "<method>"), "method", line, |b| {
+                            for s in body.stmts.iter() {
+                                let _ = b.visit_stmt(s);
+                            }
+                        });
+                    }
+                }
+                // PHP 8.4 property hooks (`get`/`set`) hold runnable code.
+                ClassMemberKind::Property(p) => self.lower_hooks(&p.hooks),
+                ClassMemberKind::ClassConst(_) | ClassMemberKind::TraitUse(_) => {}
+            }
+        }
+    }
+
+    fn lower_hooks(&mut self, hooks: &[PropertyHook]) {
+        for hook in hooks {
+            let line = self.line(hook.span.start);
+            match &hook.body {
+                PropertyHookBody::Block(block) => {
+                    self.emit_function("<hook>".to_string(), "hook", line, |b| {
+                        for s in block.stmts.iter() {
+                            let _ = b.visit_stmt(s);
+                        }
+                    });
+                }
+                PropertyHookBody::Expression(expr) => {
+                    self.emit_function("<hook>".to_string(), "hook", line, |b| {
+                        let _ = b.visit_expr(expr);
+                    });
+                }
+                PropertyHookBody::Abstract => {}
+            }
+        }
+    }
+
+    // ---- expressions ------------------------------------------------------
+
+    fn lower_expr(&mut self, expr: &Expr) {
+        match &expr.kind {
+            ExprKind::Closure(c) => {
+                let name = self
+                    .pending_name
+                    .take()
+                    .unwrap_or_else(|| "<closure>".into());
+                let line = self.line(expr.span.start);
+                self.emit_function(name, "closure", line, |b| {
+                    for s in c.body.stmts.iter() {
+                        let _ = b.visit_stmt(s);
+                    }
+                });
+            }
+            ExprKind::ArrowFunction(a) => {
+                let name = self.pending_name.take().unwrap_or_else(|| "<arrow>".into());
+                let line = self.line(expr.span.start);
+                self.emit_function(name, "arrow", line, |b| {
+                    let _ = b.visit_expr(&a.body);
+                });
+            }
+            ExprKind::Ternary(t) => {
+                let test = self.collect(|b| {
+                    let _ = b.visit_expr(&t.condition);
+                });
+                // The short ternary `$a ?: $b` has no `then` expression.
+                let then = match &t.then_expr {
+                    Some(e) => self.collect(|b| {
+                        let _ = b.visit_expr(e);
+                    }),
+                    None => Vec::new(),
+                };
+                let alternate = self.collect(|b| {
+                    let _ = b.visit_expr(&t.else_expr);
+                });
+                self.emit(Node::Conditional {
+                    test,
+                    then,
+                    alternate,
+                });
+            }
+            ExprKind::Match(m) => {
+                // The subject runs at the match's own level, before its arms.
+                let _ = self.visit_expr(&m.subject);
+                let mut cases = Vec::new();
+                for arm in m.arms.iter() {
+                    let body = self.collect(|b| {
+                        if let Some(conditions) = &arm.conditions {
+                            for c in conditions.iter() {
+                                let _ = b.visit_expr(c);
+                            }
+                        }
+                        let _ = b.visit_expr(&arm.body);
+                    });
+                    cases.push(SwitchCase {
+                        is_default: arm.conditions.is_none(),
+                        body,
+                    });
+                }
+                self.emit(Node::Switch { cases });
+            }
+            // `&&` / `and` / `||` / `or` and `??` start a folded logical run.
+            _ if logical_op(&expr.kind).is_some() => {
+                let op = logical_op(&expr.kind).expect("checked");
+                let (left, right) = logical_children(&expr.kind).expect("checked");
+                let mut operands = Vec::new();
+                self.collect_logical_side(left, op, &mut operands);
+                self.collect_logical_side(right, op, &mut operands);
+                self.emit(Node::Logical { op, operands });
+            }
+            ExprKind::FunctionCall(_)
+            | ExprKind::MethodCall(_)
+            | ExprKind::NullsafeMethodCall(_)
+            | ExprKind::StaticMethodCall(_)
+            | ExprKind::StaticDynMethodCall(_) => {
+                self.emit(Node::Call {
+                    callee: callee_name(&expr.kind),
+                });
+                // Recurse into receiver + arguments (nested calls / closures).
+                let _ = walk_owned_expr(self, expr);
+            }
+            ExprKind::Assign(a) => {
+                // `$x = fn() …` / `$x = function() …` labels the next closure.
+                if let ExprKind::Variable(name) = &a.target.kind
+                    && matches!(
+                        a.value.kind,
+                        ExprKind::Closure(_) | ExprKind::ArrowFunction(_)
+                    )
+                {
+                    self.pending_name = Some(name.to_string());
+                }
+                let _ = walk_owned_expr(self, expr);
+            }
+            // Any other expression carries no score of its own; recurse into its
+            // children so nested constructs are still reached.
+            _ => {
+                let _ = walk_owned_expr(self, expr);
+            }
+        }
+    }
+
+    /// Flatten same-operator operands; a different operator nests as its own
+    /// `Logical`; any other expression becomes a `Group` of its sub-nodes.
+    /// Parentheses are transparent (`a && (b && c)` folds to one run).
+    fn collect_logical_side(&mut self, side: &Expr, op: LogicalOp, operands: &mut Vec<Node>) {
+        let side = unwrap_parens(side);
+        match logical_op(&side.kind) {
+            Some(side_op) if side_op == op => {
+                let (left, right) = logical_children(&side.kind).expect("checked");
+                self.collect_logical_side(left, op, operands);
+                self.collect_logical_side(right, op, operands);
+            }
+            Some(side_op) => {
+                let (left, right) = logical_children(&side.kind).expect("checked");
+                let mut sub = Vec::new();
+                self.collect_logical_side(left, side_op, &mut sub);
+                self.collect_logical_side(right, side_op, &mut sub);
+                operands.push(Node::Logical {
+                    op: side_op,
+                    operands: sub,
+                });
+            }
+            None => {
+                let nodes = self.collect(|b| {
+                    let _ = b.visit_expr(side);
+                });
+                operands.push(Node::Group(nodes));
+            }
+        }
+    }
+}
+
+impl OwnedVisitor for Builder {
+    fn visit_stmt(&mut self, stmt: &Stmt) -> std::ops::ControlFlow<()> {
+        self.lower_stmt(stmt);
+        std::ops::ControlFlow::Continue(())
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) -> std::ops::ControlFlow<()> {
+        self.lower_expr(expr);
+        std::ops::ControlFlow::Continue(())
+    }
+}
+
+/// Follow `Parenthesized` wrappers to the inner expression.
+fn unwrap_parens(expr: &Expr) -> &Expr {
+    match &expr.kind {
+        ExprKind::Parenthesized(inner) => unwrap_parens(inner),
+        _ => expr,
+    }
+}
+
+/// The normalized logical operator of an expression, if it is one. PHP has two
+/// precedence tiers that mean the same thing (`&&`/`and`, `||`/`or`); both
+/// normalize to the same [`LogicalOp`], and `??` maps to [`LogicalOp::Coalesce`].
+fn logical_op(kind: &ExprKind) -> Option<LogicalOp> {
+    match kind {
+        ExprKind::Binary(b) => match b.op {
+            BinaryOp::BooleanAnd | BinaryOp::LogicalAnd => Some(LogicalOp::And),
+            BinaryOp::BooleanOr | BinaryOp::LogicalOr => Some(LogicalOp::Or),
+            _ => None,
+        },
+        ExprKind::NullCoalesce(_) => Some(LogicalOp::Coalesce),
+        _ => None,
+    }
+}
+
+/// The two operands of a logical expression (`Binary` or `??`).
+fn logical_children(kind: &ExprKind) -> Option<(&Expr, &Expr)> {
+    match kind {
+        ExprKind::Binary(b) => Some((&b.left, &b.right)),
+        ExprKind::NullCoalesce(nc) => Some((&nc.left, &nc.right)),
+        _ => None,
+    }
+}
+
+/// Simple name of a directly-called callee, used for recursion detection.
+/// Returns the trailing identifier (`foo()` and `$o->foo()` and `C::foo()` all
+/// yield `Some("foo")`); a namespaced `a\b\foo()` yields `Some("foo")`.
+fn callee_name(kind: &ExprKind) -> Option<String> {
+    let name_expr = match kind {
+        ExprKind::FunctionCall(c) => &c.name,
+        ExprKind::MethodCall(c) | ExprKind::NullsafeMethodCall(c) => &c.method,
+        ExprKind::StaticMethodCall(c) => &c.method,
+        ExprKind::StaticDynMethodCall(c) => &c.method,
+        _ => return None,
+    };
+    match &name_expr.kind {
+        ExprKind::Identifier(s) => Some(s.rsplit('\\').next().unwrap_or(s).to_string()),
+        _ => None,
+    }
+}
+
+/// `true` for a multi-level `break N` / `continue N` (`N >= 2`), which jumps out
+/// of more than one enclosing loop/switch and so scores like a labelled jump.
+fn is_multi_level(level: &Option<Box<Expr>>) -> bool {
+    matches!(level.as_deref(), Some(Expr { kind: ExprKind::Int(n), .. }) if *n >= 2)
+}
+
+/// A declaration name, or `default` when the parser could not recover one.
+fn ident_name(ident: &Ident, default: &str) -> String {
+    ident
+        .as_ref()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| default.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cccc_core::report::FunctionReport;
+
+    fn analyze(src: &str) -> FileReport {
+        analyze_source(Path::new("test.php"), src)
+    }
+
+    fn find<'a>(fns: &'a [FunctionReport], name: &str) -> Option<&'a FunctionReport> {
+        for f in fns {
+            if f.name == name {
+                return Some(f);
+            }
+            if let Some(found) = find(&f.children, name) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn cognitive_of(src: &str, name: &str) -> u32 {
+        find(&analyze(src).functions, name)
+            .unwrap_or_else(|| panic!("function {name} not found"))
+            .cognitive
+    }
+
+    fn cyclomatic_of(src: &str, name: &str) -> u32 {
+        find(&analyze(src).functions, name)
+            .unwrap_or_else(|| panic!("function {name} not found"))
+            .cyclomatic
+    }
+
+    #[test]
+    fn sonar_sum_of_primes_is_7() {
+        let src = r#"<?php
+            function sumOfPrimes($max) {
+                $total = 0;
+                for ($i = 2; $i <= $max; $i++) {
+                    for ($j = 2; $j < $i; $j++) {
+                        if ($i % $j == 0) {
+                            continue 2;
+                        }
+                    }
+                    $total += $i;
+                }
+                return $total;
+            }
+        "#;
+        // for(+1) + nested for(+2) + nested if(+3) + multi-level continue(+1) = 7
+        assert_eq!(cognitive_of(src, "sumOfPrimes"), 7);
+        // base 1 + for + for + if = 4
+        assert_eq!(cyclomatic_of(src, "sumOfPrimes"), 4);
+    }
+
+    #[test]
+    fn sonar_get_words_is_1() {
+        let src = r#"<?php
+            function getWords($number) {
+                switch ($number) {
+                    case 1:
+                        return "one";
+                    case 2:
+                        return "a couple";
+                    default:
+                        return "lots";
+                }
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "getWords"), 1);
+        // base 1 + 2 non-default cases = 3
+        assert_eq!(cyclomatic_of(src, "getWords"), 3);
+    }
+
+    #[test]
+    fn nested_if_adds_nesting() {
+        let src = r#"<?php
+            function f($a, $b, $c) {
+                if ($a) {
+                    if ($b) {
+                        if ($c) {
+                        }
+                    }
+                }
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 6);
+    }
+
+    #[test]
+    fn elseif_else_are_flat() {
+        let src = r#"<?php
+            function f($a, $b) {
+                if ($a) {
+                } elseif ($b) {
+                } else {
+                }
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 3);
+        // base 1 + if + elseif = 3 (the else is not a decision point)
+        assert_eq!(cyclomatic_of(src, "f"), 3);
+    }
+
+    #[test]
+    fn loops_all_count() {
+        let src = r#"<?php
+            function f($a, $items) {
+                while ($a) {
+                }
+                for ($i = 0; $i < 3; $i++) {
+                }
+                foreach ($items as $i) {
+                }
+                do {
+                } while ($a);
+            }
+        "#;
+        // four loops, each +1 at nesting 0
+        assert_eq!(cognitive_of(src, "f"), 4);
+    }
+
+    #[test]
+    fn logical_sequences_fold_by_operator() {
+        let src = r#"<?php
+            function f($a, $b, $c, $d) {
+                if ($a && $b && $c || $d) {
+                }
+            }
+        "#;
+        // if(+1) + && run(+1) + || run(+1) = 3
+        assert_eq!(cognitive_of(src, "f"), 3);
+        // base 1 + if 1 + (&& 3 operands => +2) + (|| 2 operands => +1) = 5
+        assert_eq!(cyclomatic_of(src, "f"), 5);
+    }
+
+    #[test]
+    fn keyword_and_or_are_logical_and_fold_with_symbols() {
+        let src = r#"<?php
+            function f($a, $b, $c) {
+                if ($a && $b and $c) {
+                }
+            }
+        "#;
+        // `&&` and `and` are the same normalized operator → one folded run.
+        // if(+1) + and-run(+1) = 2
+        assert_eq!(cognitive_of(src, "f"), 2);
+    }
+
+    #[test]
+    fn null_coalesce_is_one_logical_run() {
+        let src = r#"<?php
+            function f($a, $b, $c) {
+                return $a ?? $b ?? $c;
+            }
+        "#;
+        // a single folded `??` run = +1
+        assert_eq!(cognitive_of(src, "f"), 1);
+    }
+
+    #[test]
+    fn ternary_is_a_conditional() {
+        let src = r#"<?php
+            function f($a) {
+                return $a ? 1 : 2;
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 1);
+        assert_eq!(cyclomatic_of(src, "f"), 2);
+    }
+
+    #[test]
+    fn match_scores_like_a_switch() {
+        let src = r#"<?php
+            function f($x) {
+                return match ($x) {
+                    1, 2 => "a",
+                    3 => "b",
+                    default => "c",
+                };
+            }
+        "#;
+        // match(+1) = 1
+        assert_eq!(cognitive_of(src, "f"), 1);
+        // base 1 + 2 non-default arms = 3
+        assert_eq!(cyclomatic_of(src, "f"), 3);
+    }
+
+    #[test]
+    fn catch_clause_counts() {
+        let src = r#"<?php
+            function f() {
+                try {
+                    risky();
+                } catch (\Exception $e) {
+                    handle();
+                }
+            }
+        "#;
+        // catch(+1) = 1
+        assert_eq!(cognitive_of(src, "f"), 1);
+        // base 1 + catch 1 = 2
+        assert_eq!(cyclomatic_of(src, "f"), 2);
+    }
+
+    #[test]
+    fn recursion_adds_one_per_call() {
+        let src = r#"<?php
+            function fib($n) {
+                if ($n < 2) {
+                    return $n;
+                }
+                return fib($n - 1) + fib($n - 2);
+            }
+        "#;
+        // if(+1) + two recursive calls(+2) = 3
+        assert_eq!(cognitive_of(src, "fib"), 3);
+    }
+
+    #[test]
+    fn method_recursion_is_detected() {
+        let src = r#"<?php
+            class S {
+                function walk($n) {
+                    if ($n == 0) {
+                        return 0;
+                    } else {
+                        return $this->walk($n - 1);
+                    }
+                }
+            }
+        "#;
+        // if(+1) + else(+1) + recursion(+1) = 3
+        assert_eq!(cognitive_of(src, "walk"), 3);
+        assert_eq!(
+            find(&analyze(src).functions, "walk").unwrap().kind,
+            "method"
+        );
+    }
+
+    #[test]
+    fn static_method_recursion_is_detected() {
+        let src = r#"<?php
+            class S {
+                static function fib($n) {
+                    if ($n < 2) {
+                        return $n;
+                    }
+                    return self::fib($n - 1) + self::fib($n - 2);
+                }
+            }
+        "#;
+        // if(+1) + two recursive calls(+2) = 3
+        assert_eq!(cognitive_of(src, "fib"), 3);
+    }
+
+    #[test]
+    fn closure_is_its_own_unit_and_named() {
+        let src = r#"<?php
+            function host() {
+                $pick = function ($a, $b) {
+                    if ($a && $b) {
+                        return 1;
+                    } else {
+                        return 0;
+                    }
+                };
+                return $pick;
+            }
+        "#;
+        // host owns no structural complexity; the closure does.
+        assert_eq!(cognitive_of(src, "host"), 0);
+        // if(+1) + && run(+1) + else(+1) = 3
+        assert_eq!(cognitive_of(src, "pick"), 3);
+        assert_eq!(
+            find(&analyze(src).functions, "pick").unwrap().kind,
+            "closure"
+        );
+    }
+
+    #[test]
+    fn arrow_function_is_its_own_unit_and_named() {
+        let src = r#"<?php
+            function host() {
+                $f = fn ($x) => $x && $x;
+                return $f;
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "host"), 0);
+        // && run(+1) = 1
+        assert_eq!(cognitive_of(src, "f"), 1);
+        assert_eq!(find(&analyze(src).functions, "f").unwrap().kind, "arrow");
+    }
+
+    #[test]
+    fn multi_level_break_is_labelled_but_plain_break_is_flat() {
+        let labelled = r#"<?php
+            function f($items) {
+                foreach ($items as $i) {
+                    while (true) {
+                        break 2;
+                    }
+                }
+            }
+        "#;
+        // foreach(+1) + while(+2) + multi-level break(+1) = 4
+        assert_eq!(cognitive_of(labelled, "f"), 4);
+
+        let plain = r#"<?php
+            function f($items) {
+                foreach ($items as $i) {
+                    if ($i) {
+                        break;
+                    }
+                }
+            }
+        "#;
+        // foreach(+1) + if(+2) + plain break(0) = 3
+        assert_eq!(cognitive_of(plain, "f"), 3);
+    }
+
+    #[test]
+    fn file_total_sums_all_functions() {
+        let src = r#"<?php
+            function a($x) {
+                if ($x) {
+                }
+            }
+            function b($y) {
+                if ($y) {
+                }
+            }
+        "#;
+        assert_eq!(analyze(src).cognitive, 2);
+    }
+
+    #[test]
+    fn parse_error_is_reported() {
+        // `php-rs-parser` is fault-tolerant: it still yields a (partial) AST, but
+        // surfaces a diagnostic for the broken input.
+        let (_nodes, errors) = to_ir(Path::new("bad.php"), "<?php function f( {");
+        assert!(!errors.is_empty());
+    }
+}

--- a/crates/cccc-php/src/lib.rs
+++ b/crates/cccc-php/src/lib.rs
@@ -462,6 +462,14 @@ impl Builder {
                 // Recurse into receiver + arguments (nested calls / closures).
                 let _ = walk_owned_expr(self, expr);
             }
+            // `new class { … }` lowers its members exactly like a named class:
+            // each method becomes its own `Function` unit rather than folding
+            // into the surrounding frame.
+            ExprKind::AnonymousClass(c) => {
+                self.lower_class(c);
+                // Still recurse into the `new`'s arguments for nested calls /
+                // closures, but skip the class body (already lowered above).
+            }
             ExprKind::Assign(a) => {
                 // `$x = fn() …` / `$x = function() …` labels the next closure.
                 if let ExprKind::Variable(name) = &a.target.kind
@@ -907,6 +915,34 @@ mod tests {
         "#;
         // foreach(+1) + if(+2) + plain break(0) = 3
         assert_eq!(cognitive_of(plain, "f"), 3);
+    }
+
+    #[test]
+    fn anonymous_class_methods_are_their_own_units() {
+        let src = r#"<?php
+            function host($cb) {
+                $obj = new class($cb, fn ($z) => $z && $z) {
+                    public function m($x) {
+                        if ($x) {
+                            return 1;
+                        }
+                        return 0;
+                    }
+                    public function n($y) {
+                        return $y ?? 0;
+                    }
+                };
+                return $obj;
+            }
+        "#;
+        // The anonymous class's methods must each be their own Function unit,
+        // not folded into `host`, which itself owns no structural complexity.
+        assert_eq!(cognitive_of(src, "host"), 0);
+        assert_eq!(cognitive_of(src, "m"), 1); // if
+        assert_eq!(cognitive_of(src, "n"), 1); // ??
+        assert_eq!(find(&analyze(src).functions, "m").unwrap().kind, "method");
+        // A closure passed as a constructor argument is still reached.
+        assert_eq!(cognitive_of(src, "<arrow>"), 1); // &&
     }
 
     #[test]


### PR DESCRIPTION
## 概要

他言語フロントエンド（`cccc-es` / `cccc-rs` / `cccc-go`）と同じ二段構成で **PHP対応** を追加します。

## 追加クレート

| クレート | 役割 |
|---|---|
| `crates/cccc-php` | アダプタライブラリ。`php-rs-parser` の AST を `cccc-core` の IR に lowering。依存は `cccc-core` + `php-rs-parser` / `php-ast` のみ（純Rust・C依存なし）、CLI依存なし |
| `crates/cccc-php-cli` | `cccc-php` バイナリ。`cccc_cli::run(...)` に繋ぐ薄いシェル |

lowering は `php-ast` の `OwnedVisitor`（フルトラバーサル）で駆動し、想定外の位置にあるネスト構造（既定引数内のクロージャ等）も取りこぼしません。`docs/ADDING_A_LANGUAGE.md` の推奨パターンに準拠しています。

## PHP → IR マッピング

- 関数 / メソッド / クロージャ / `fn` アロー / プロパティフック → `Function`（クロージャ・アローは `$f = fn()…` の変数名を継承）
- `if` / `elseif` / `else` → `Branch`（`elseif` はネストした `Branch` でフラット採点）
- 三項 `?:` → `Conditional`、`??` → `Logical(Coalesce)`
- `while` / `do-while` / `for` / `foreach` → `Loop`
- `switch` と `match` 式 → `Switch`（`default` は非判定アーム）
- `catch` 句 → `Catch`
- `goto` と多段 `break N` / `continue N`（N≥2）→ ラベル付き `Jump`
- `&&` / `and` / `||` / `or` / `??` → 畳み込み `Logical`（`&&` と `and`、`||` と `or` は同一演算子として正規化）
- 関数 / メソッド / 静的呼び出し → `Call`（`$this->m()`・`self::m()` を含む再帰検出）

## パーサ選定

`php-rs-parser` 0.18.1（+ `php-ast`）を採用。純Rust・C toolchain不要でクロスコンパイルがクリーン、`OwnedVisitor` のフルトラバーサルを備え、rustc 1.95 で動作。lifetime-free な owned AST によりアリーナ管理が不要。

## テスト

- アダプタ単体テスト **20件**（SonarSource の `sumOfPrimes`=7 / `getWords`=1 等に加え、クロージャ / アロー / `match` / `try`-`catch` / `??` / 再帰 / 多段 `break` / 匿名クラスをカバー）
- CLI統合テスト **14件**（Go版と同一の期待値）
- ワークスペース全体で fmt クリーン / clippy `-D warnings` クリーン / 全テスト緑 / リリースビルド成功
- namespace・trait・enum・`match`・`try`/`catch`/`finally`・ネストした `&&`/`||`・再帰・名前付きクロージャを含む実物大PHPでもスモークテスト済み

## 実プロジェクトでの計測結果

合成テストに加え、実在の PHP プロジェクト 5 件（合計 **140 `.php` ファイル**）をリリースビルドの `cccc-php` で計測しました。**全ファイルがパースエラーゼロ**で処理できました。

| プロジェクト | files | functions | cognitive (sum / max) | cyclomatic (sum / max) | 最大ホットスポット |
|---|--:|--:|--:|--:|---|
| [uzulla/Ore](https://github.com/uzulla/Ore) | 7 | 21 | 23 / 7 | 41 / 6 | `find_match_path` (cog 7) |
| [uzulla/Ore2](https://github.com/uzulla/Ore2) | 31 | 110 | 83 / 16 | 172 / 10 | `Logger::log` (cog 16) |
| [uzulla/Ore3](https://github.com/uzulla/Ore3) | 27 | 59 | 57 / 11 | 114 / 19 | `validateFile` (cog 11, cyc 19) |
| [uzulla/Keira](https://github.com/uzulla/Keira) | 23 | 132 | 177 / 18 | 268 / 12 | `MonitorManager::configure` (cog 18) |
| [uzulla/PPQB](https://github.com/uzulla/PPQB) | 52 | 255 | 789 / 169 | 774 / 67 | `generateReport` (cog 169, cyc 67) |

### 妥当性の確認

結果は実コードに照らして妥当でした。

- **堅牢性**: namespace / trait / enum / `match` / `try`-`catch` / クロージャ / アロー関数 / `??` を含む実コードを 5 リポジトリすべてエラーなく処理。
- **下限が正しい**: 単純な getter・ルーティング関数は cognitive 0（`open_db`・`e`・`redirect` 等）。クロージャは独立ユニットとして親にネスト表示され、行番号・関数種別（function/method/closure）も正確。
- **上限が正しい**: 最大の `PPQB/generate_compatibility_report.php` の `generateReport`（cog 169 / cyc 67）を生のキーワード数で照合 — 同ファイルは 466 行に `if` 33・`foreach` 26・`for` 7・`while` 1・`elseif` 1・`&&` 8（≈ 判定点 76）を含み、そのほとんどが 1 つの深くネストした関数に集中。**cyclomatic 67 は判定点数とほぼ一致**し、**cognitive 169 がそれを大きく上回るのはネスト深さのペナルティ**で、「巨大かつ深ネストのレポート生成関数」の典型的シグネチャと内部的に整合。
- **2 指標が別側面を捉えている**ことも実データで確認: `Ore3/validateFile` は cyclomatic 19 > cognitive 11（フラットな多数分岐＝McCabe は高いがネストが浅い）、逆に `generateReport` は cognitive ≫ cyclomatic（深ネスト）。

## 補足

- `dependabot.yml` は `directory: "/"` でワークスペース全体を対象にしているため、新クレートは自動でカバーされます（変更不要）。
- `break N` / `continue N`（N≥2）と `goto` を「ラベル付きジャンプ（+1）」として扱っています。PHPには明示ラベルが無いため、複数階層を抜ける多段 `break` を Go のラベル付き `break` 相当と解釈した判断です（README / コードに明記）。
