### PR TITLE
Add Ruby front-end (cccc-rb)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # cccc-rb builds Ruby's Prism from vendored C via bindgen, which needs libclang.
+      - name: Install libclang (for the ruby-prism / bindgen build)
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
       - name: Run tests
         run: cargo test --workspace --all-targets --all-features
 
@@ -45,5 +48,8 @@ jobs:
           toolchain: stable
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # cccc-rb builds Ruby's Prism from vendored C via bindgen, which needs libclang.
+      - name: Install libclang (for the ruby-prism / bindgen build)
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -1,0 +1,100 @@
+name: Cross build
+
+# Builds the unified `cccc` binary for every release target on PRs, so that the
+# cross-compilation of `cccc-rb` (Ruby's Prism, a vendored C library built via
+# bindgen) is validated before a tag is cut. Mirrors the target matrix in
+# release.yml.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: cross-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            tool: zigbuild
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            tool: zigbuild
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            tool: cargo
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            tool: cargo
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            tool: cargo
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: ${{ matrix.target }}
+
+      # --- Linux (musl): zig supplies the target C compiler + linker for the
+      # vendored Prism sources; host libclang drives bindgen. ---
+      - name: Install libclang (bindgen)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+
+      - name: Set up Zig
+        if: matrix.tool == 'zigbuild'
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.13.0
+
+      - name: Install cargo-zigbuild
+        if: matrix.tool == 'zigbuild'
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
+        with:
+          tool: cargo-zigbuild
+
+      # --- Windows: MSVC (cl.exe) compiles the vendored Prism sources; the
+      # runner ships LLVM, so point bindgen at its libclang. ---
+      - name: Point bindgen at the preinstalled libclang (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "LIBCLANG_PATH=C:\\Program Files\\LLVM\\bin" >> "$GITHUB_ENV"
+
+      - name: Build (zigbuild)
+        if: matrix.tool == 'zigbuild'
+        run: cargo zigbuild --release --target ${{ matrix.target }} --bin cccc
+
+      - name: Build (cargo)
+        if: matrix.tool == 'cargo'
+        run: cargo build --release --target ${{ matrix.target }} --bin cccc
+
+      # Smoke-check the produced binary where it can run natively (host == target):
+      # x86_64 Linux/Windows runners and the arm64 macOS runner.
+      - name: Smoke-test the native binary (Unix)
+        if: matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-apple-darwin'
+        shell: bash
+        run: |
+          bin="target/${{ matrix.target }}/release/cccc"
+          "$bin" --lang ruby --table crates/cccc-cli/tests/fixtures/sample.rb
+
+      - name: Smoke-test the native binary (Windows)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        run: |
+          & "target/${{ matrix.target }}/release/cccc.exe" --lang ruby --table crates/cccc-cli/tests/fixtures/sample.rb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,24 +34,51 @@ jobs:
           - aarch64-apple-darwin
           - x86_64-pc-windows-msvc
         include:
+          # The two musl targets build the vendored Prism C sources for a
+          # foreign libc, so they cross-compile with cargo-zigbuild (zig provides
+          # the target C toolchain + linker); the rest build natively with cargo.
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+            build-tool: cargo-zigbuild
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
+            build-tool: cargo-zigbuild
           - target: x86_64-apple-darwin
             os: macos-latest
+            build-tool: cargo
           - target: aarch64-apple-darwin
             os: macos-latest
+            build-tool: cargo
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+            build-tool: cargo
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # cccc-rb builds Ruby's Prism from vendored C via bindgen, which needs
+      # libclang on the host that runs the build.
+      - name: Install libclang (bindgen)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+
+      - name: Set up Zig (cargo-zigbuild cross C toolchain)
+        if: matrix.build-tool == 'cargo-zigbuild'
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.13.0
+
+      - name: Point bindgen at the preinstalled libclang (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: echo "LIBCLANG_PATH=C:\\Program Files\\LLVM\\bin" >> "$GITHUB_ENV"
+
       - uses: taiki-e/upload-rust-binary-action@dd5bbe0528f32a483b749797277ab6ef83a29999
         with:
           # The unified cccc binary.
           bin: ${{ matrix.bin }}
           target: ${{ matrix.target }}
+          build-tool: ${{ matrix.build-tool }}
           # Archive name: cccc-<tag>-<target>.{tar.gz,zip}
           archive: $bin-$tag-$target
           # Bundle docs/license alongside the binary in the archive.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +186,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex 2.0.1",
+]
+
+[[package]]
 name = "cccc-cli"
 version = "1.0.0"
 dependencies = [
@@ -174,6 +204,7 @@ dependencies = [
  "cccc-es",
  "cccc-go",
  "cccc-php",
+ "cccc-rb",
  "cccc-rs",
  "clap",
  "globset",
@@ -223,6 +254,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cccc-rb"
+version = "1.0.0"
+dependencies = [
+ "cccc-core",
+ "ruby-prism",
+]
+
+[[package]]
 name = "cccc-rs"
 version = "1.0.0"
 dependencies = [
@@ -232,10 +271,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -369,6 +428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +447,12 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -462,6 +533,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +552,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -528,12 +618,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -937,6 +1043,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1118,27 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "ruby-prism"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b302f00359d0b5423a600314935ca5f994484e15da2db5345631d28c6e029d6"
+dependencies = [
+ "ruby-prism-sys",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ruby-prism-sys"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f85fd9571455bdca2b3bf0b2f543cd13ac39d5de0026a8eb2deb94ffd264f00"
+dependencies = [
+ "bindgen",
+ "cc",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -1106,6 +1243,18 @@ checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/cccc-rs",
     "crates/cccc-go",
     "crates/cccc-php",
+    "crates/cccc-rb",
 ]
 resolver = "2"
 
@@ -23,6 +24,7 @@ cccc-es = { path = "crates/cccc-es", version = "1.0.0" }
 cccc-rs = { path = "crates/cccc-rs", version = "1.0.0" }
 cccc-go = { path = "crates/cccc-go", version = "1.0.0" }
 cccc-php = { path = "crates/cccc-php", version = "1.0.0" }
+cccc-rb = { path = "crates/cccc-rb", version = "1.0.0" }
 serde = { version = "1", features = ["derive"] }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - A fast CLI — a **single `cccc` binary** — that measures **Cognitive Complexity**
   (SonarSource / G. Ann Campbell) and **Cyclomatic Complexity** (McCabe). Written
   in Rust. It routes each file to the right front-end by its extension, so one run
-  can analyze a mixed-language tree. Four languages ship today, all sharing the
+  can analyze a mixed-language tree. Five languages ship today, all sharing the
   same engine, flags, and output format:
   - **TypeScript / JavaScript** (`--lang es`), via the [oxc](https://oxc.rs)
     parser. Analyzes `.ts`, `.tsx`, `.js`, `.jsx`, `.mts`, `.cts`, `.mjs`, `.cjs`.
@@ -11,6 +11,8 @@
   - **Go** (`--lang go`), via the [gosyn](https://docs.rs/gosyn) parser. `.go`.
   - **PHP** (`--lang php`), via the [php-rs-parser](https://docs.rs/php-rs-parser)
     parser. `.php`.
+  - **Ruby** (`--lang ruby`), via the [ruby-prism](https://docs.rs/ruby-prism)
+    parser (Ruby's official Prism parser). `.rb`.
 - A Rust library for calculating cognitive and cyclomatic complexity in a language-agnostic way
 
 ## Workspace layout
@@ -26,6 +28,7 @@ library and extended to other languages:
 | [`cccc-rs`](crates/cccc-rs) | Rust adapter **library**: lowers the [syn](https://docs.rs/syn) AST into `cccc-core`'s IR. Depends only on `cccc-core` + syn — **no CLI dependencies**. |
 | [`cccc-go`](crates/cccc-go) | Go adapter **library**: lowers the [gosyn](https://docs.rs/gosyn) AST into `cccc-core`'s IR. Depends only on `cccc-core` + gosyn — **no CLI dependencies**. |
 | [`cccc-php`](crates/cccc-php) | PHP adapter **library**: lowers the [php-rs-parser](https://docs.rs/php-rs-parser) AST into `cccc-core`'s IR. Depends only on `cccc-core` + php-rs-parser / php-ast — **no CLI dependencies**. |
+| [`cccc-rb`](crates/cccc-rb) | Ruby adapter **library**: lowers the [ruby-prism](https://docs.rs/ruby-prism) AST into `cccc-core`'s IR. Depends only on `cccc-core` + ruby-prism — **no CLI dependencies**. Note: ruby-prism is an FFI binding to the vendored Prism C source, so building this crate (unlike the others) needs a C99 compiler and libclang. |
 
 Each adapter is a standalone library so that a consumer who only wants the
 metrics pulls in just that adapter (+ `cccc-core` + its parser), never clap /
@@ -36,8 +39,8 @@ To support another language: (1) add an adapter crate that lowers its AST into
 `cccc_core::ir::Node` and calls `cccc_core::engine::analyze`, then (2) register
 it with one entry in `cccc-cli`'s `lang::LANGUAGES` (and add the dependency) —
 no new binary, and no reimplementing the metrics or the CLI. `cccc-es` (oxc),
-`cccc-rs` (syn), `cccc-go` (gosyn), and `cccc-php` (php-rs-parser) are the
-reference adapters: same shape, different parser.
+`cccc-rs` (syn), `cccc-go` (gosyn), `cccc-php` (php-rs-parser), and `cccc-rb`
+(ruby-prism) are the reference adapters: same shape, different parser.
 
 **See [docs/ADDING_A_LANGUAGE.md](docs/ADDING_A_LANGUAGE.md) for the full
 step-by-step guide**, including the IR-node reference table, the

--- a/crates/cccc-cli/Cargo.toml
+++ b/crates/cccc-cli/Cargo.toml
@@ -18,6 +18,7 @@ cccc-es = { workspace = true }
 cccc-rs = { workspace = true }
 cccc-go = { workspace = true }
 cccc-php = { workspace = true }
+cccc-rb = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 globset = "0.4"
 ignore = "0.4"

--- a/crates/cccc-cli/src/lang.rs
+++ b/crates/cccc-cli/src/lang.rs
@@ -58,6 +58,12 @@ pub const LANGUAGES: &[Language] = &[
         exts: cccc_php::DEFAULT_EXTS,
         analyze: cccc_php::analyze_source,
     },
+    Language {
+        name: "ruby",
+        aliases: &["rb"],
+        exts: cccc_rb::DEFAULT_EXTS,
+        analyze: cccc_rb::analyze_source,
+    },
 ];
 
 /// Resolve the active languages from an `include` (`--lang`) and an `exclude`
@@ -203,7 +209,11 @@ mod tests {
 
     #[test]
     fn exclude_removes_from_all() {
-        let langs = resolve_languages(None, Some(&["go".to_string(), "php".to_string()])).unwrap();
+        let langs = resolve_languages(
+            None,
+            Some(&["go".to_string(), "php".to_string(), "ruby".to_string()]),
+        )
+        .unwrap();
         assert_eq!(names(&langs), vec!["es", "rust"]);
     }
 
@@ -238,7 +248,7 @@ mod tests {
     fn dispatch_covers_each_extension() {
         let all = resolve_languages(None, None).unwrap();
         let map = build_dispatch(&all, &BTreeMap::new());
-        for key in ["ts", "rs", "go", "php"] {
+        for key in ["ts", "rs", "go", "php", "rb"] {
             assert!(map.contains_key(key), "missing dispatch for .{key}");
         }
     }

--- a/crates/cccc-cli/tests/cli.rs
+++ b/crates/cccc-cli/tests/cli.rs
@@ -242,14 +242,20 @@ fn analyzes_all_languages_in_one_run() {
     // The fixtures dir holds one file per language; a single run dispatches each
     // by extension and reports them all together.
     let v = json(&["tests/fixtures"]);
-    assert_eq!(v["summary"]["file_count"], 4);
+    assert_eq!(v["summary"]["file_count"], 5);
     let paths: Vec<String> = v["files"]
         .as_array()
         .unwrap()
         .iter()
         .map(|f| f["path"].as_str().unwrap().to_string())
         .collect();
-    for ext in ["sample.ts", "sample.rs", "sample.go", "sample.php"] {
+    for ext in [
+        "sample.ts",
+        "sample.rs",
+        "sample.go",
+        "sample.php",
+        "sample.rb",
+    ] {
         assert!(paths.iter().any(|p| p.ends_with(ext)), "missing {ext}");
     }
 }
@@ -281,8 +287,8 @@ fn unknown_lang_is_an_error() {
 
 #[test]
 fn exclude_lang_drops_a_language() {
-    // All languages minus Go and PHP leaves the .ts and .rs fixtures.
-    let v = json(&["--exclude-lang", "go,php", "tests/fixtures"]);
+    // All languages minus Go, PHP and Ruby leaves the .ts and .rs fixtures.
+    let v = json(&["--exclude-lang", "go,php,ruby", "tests/fixtures"]);
     let mut exts: Vec<String> = v["files"]
         .as_array()
         .unwrap()
@@ -324,7 +330,7 @@ fn exclude_lang_combines_with_lang() {
 fn excluding_every_language_is_an_error() {
     Command::cargo_bin("cccc")
         .unwrap()
-        .args(["--exclude-lang", "es,rust,go,php", "tests/fixtures"])
+        .args(["--exclude-lang", "es,rust,go,php,ruby", "tests/fixtures"])
         .assert()
         .failure()
         .code(2)

--- a/crates/cccc-cli/tests/fixtures/sample.rb
+++ b/crates/cccc-cli/tests/fixtures/sample.rb
@@ -1,0 +1,39 @@
+# Fixture with known complexity values, used by integration tests.
+
+# Cognitive: for(+1) + nested for(+2) + nested if(+3) + else(+1 flat) = 7
+# Cyclomatic: base 1 + for + for + if = 4
+# (Ruby has no labelled `next`, so the flat `else` supplies the 7th cognitive
+#  point that the other languages get from a labelled `continue`.)
+def sum_of_primes(max)
+  total = 0
+  for i in 2..max
+    for j in 2...i
+      if i % j == 0
+        total += 0
+      else
+        total += i
+      end
+    end
+  end
+  total
+end
+
+# Cognitive: case(+1) = 1 ; Cyclomatic: base 1 + 2 non-default whens = 3
+def get_words(n)
+  case n
+  when 1
+    "one"
+  when 2
+    "a couple"
+  else
+    "lots"
+  end
+end
+
+# Cognitive: if(+1) + &&(+1) = 2 ; Cyclomatic: base 1 + if + && = 3
+def classify(a, b)
+  if a && b
+    return "both"
+  end
+  "not"
+end

--- a/crates/cccc-cli/tests/lang_smoke.rs
+++ b/crates/cccc-cli/tests/lang_smoke.rs
@@ -49,3 +49,8 @@ fn go_fixture_dispatches() {
 fn php_fixture_dispatches() {
     assert_sum_of_primes("sample.php", "sumOfPrimes");
 }
+
+#[test]
+fn ruby_fixture_dispatches() {
+    assert_sum_of_primes("sample.rb", "sum_of_primes");
+}

--- a/crates/cccc-rb/Cargo.toml
+++ b/crates/cccc-rb/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "cccc-rb"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Ruby (ruby-prism) adapter that lowers source into the cccc-core complexity IR"
+
+[dependencies]
+cccc-core = { workspace = true }
+# Ruby's official parser (Prism). Unlike the other adapters this is an FFI
+# binding to the vendored Prism C source (built statically via `cc`, with
+# `bindgen` generating the bindings), so building this crate requires a C99
+# compiler and libclang. `ruby-prism` provides the `Visit` full-traversal trait
+# we drive lowering from.
+ruby-prism = "1.9.0"

--- a/crates/cccc-rb/src/lib.rs
+++ b/crates/cccc-rb/src/lib.rs
@@ -1,0 +1,836 @@
+//! Ruby adapter: parses source with [ruby-prism](https://docs.rs/ruby-prism)
+//! (the Rust binding to Ruby's official Prism parser) and lowers the AST into the
+//! language-agnostic [`cccc_core::ir`].
+//!
+//! Unlike the other adapters this one is **not** pure Rust: `ruby-prism` is an
+//! FFI binding to the vendored Prism C source, so building this crate needs a C99
+//! compiler and libclang (bindgen). In exchange we get Ruby's canonical parser
+//! and its [`Visit`] full-traversal trait, which we drive lowering from — exactly
+//! as `cccc-php` drives lowering from `php-ast`'s visitor.
+//!
+//! This crate contains **no scoring logic** — it only recognizes the constructs
+//! the engine cares about (`def`/blocks/lambdas, `if`/`elsif`/`else`/`unless`,
+//! ternary, `while`/`until`/`for`, `case`/`when` and `case`/`in`, `rescue`,
+//! `&&`/`and`/`||`/`or`, calls) and emits the matching IR nodes. All complexity
+//! rules live in [`cccc_core::engine`].
+//!
+//! ## Lowering strategy
+//!
+//! Prism's [`Visit`] trait has one `visit_*_node` method per node type, each with
+//! a default that walks every child. We override only the structural nodes and
+//! assemble the IR with a stack of "collectors" ([`Builder::collect`]); anything
+//! we don't override is reached by the default walk, so a construct in an
+//! unexpected position (a block in an argument, an operator inside an index) is
+//! never silently missed.
+//!
+//! ## Ruby-to-IR mapping notes
+//!
+//! - `def` (incl. `def self.m`) → [`Node::Function`] (`"method"`); a block
+//!   (`{ }` / `do…end`) → `"block"`; a `-> { }` lambda → `"lambda"`. Each is its
+//!   own unit (nesting resets), matching how the ES/PHP adapters treat
+//!   arrows/closures. A block borrows the name of the method it is passed to
+//!   (`xs.each { }` → `each`).
+//! - `if` / `elsif` / `else` and `unless` → [`Node::Branch`] (chaining `elsif` as
+//!   a nested `Branch` so it scores flat). The ternary `a ? b : c` is a keyword-
+//!   less `IfNode`, lowered to [`Node::Conditional`] so its `else` is not a second
+//!   increment.
+//! - `while` / `until` / `for` (and their modifier forms) → [`Node::Loop`].
+//! - `case`/`when` and `case`/`in` (pattern matching) → [`Node::Switch`]; the
+//!   `else` arm is not a cyclomatic decision point.
+//! - `rescue` clauses (and the modifier `x rescue y`) → [`Node::Catch`]; the
+//!   `begin`/`else`/`ensure` bodies score at the surrounding level.
+//! - `&&` / `and` / `||` / `or` runs → folded [`Node::Logical`] (one node per
+//!   like-operator run; `and`/`&&` normalize to the same operator, as do
+//!   `or`/`||`). Ruby has no `??`.
+//! - calls → [`Node::Call`] for recursion detection (`m()`, `obj.m()`,
+//!   `self.m()` all yield `Some("m")`).
+//!
+//! Ruby has no labelled `break`/`next`, so those never produce a cognitive point
+//! and are left to the default walk. Method-based iteration (`loop { }`,
+//! `n.times { }`) is modelled as a block unit, not a `Loop`, since only the
+//! syntactic loop keywords are recognized — the same syntax-only stance the other
+//! adapters take.
+
+use std::path::Path;
+
+use cccc_core::engine;
+use cccc_core::ir::{LogicalOp, Node, SwitchCase};
+use cccc_core::report::FileReport;
+use ruby_prism::{
+    AndNode, BeginNode, BlockNode, CallNode, CaseMatchNode, CaseNode, DefNode, ForNode, IfNode,
+    LambdaNode, Node as PrismNode, OrNode, RescueModifierNode, StatementsNode, UnlessNode,
+    UntilNode, Visit, WhileNode, parse,
+};
+
+/// File extensions analyzed by default (when `--ext` is not given).
+pub const DEFAULT_EXTS: &[&str] = &["rb"];
+
+/// Parse `source` and produce its [`FileReport`], scoring via the core engine.
+/// This is the convenience entry point used by the CLI; for the raw IR use
+/// [`to_ir`].
+pub fn analyze_source(path: &Path, source: &str) -> FileReport {
+    let (nodes, parse_errors) = to_ir(path, source);
+    engine::analyze(&path.display().to_string(), &nodes, parse_errors)
+}
+
+/// Parse `source` and lower it to the complexity IR, returning the module-level
+/// nodes plus any parser error messages. Prism is fault-tolerant: it always
+/// yields a (possibly partial) AST, so we lower whatever it recovered and surface
+/// the diagnostics alongside.
+pub fn to_ir(_path: &Path, source: &str) -> (Vec<Node>, Vec<String>) {
+    let result = parse(source.as_bytes());
+    let parse_errors: Vec<String> = result.errors().map(|e| e.message().to_string()).collect();
+
+    let mut builder = Builder::new(source);
+    let root = result.node();
+    builder.visit(&root);
+    (builder.finish(), parse_errors)
+}
+
+/// Assembles the IR tree while Prism's [`Visit`] trait drives a complete AST
+/// traversal.
+struct Builder {
+    /// Stack of node collectors. `stack.last_mut()` receives emitted nodes;
+    /// structural nodes push a fresh collector for their body, then pop it.
+    stack: Vec<Vec<Node>>,
+    /// Byte offset of the start of each 1-based line, for offset → line lookup.
+    line_starts: Vec<u32>,
+}
+
+impl Builder {
+    fn new(source: &str) -> Self {
+        let mut line_starts = vec![0u32];
+        for (i, b) in source.bytes().enumerate() {
+            if b == b'\n' {
+                line_starts.push((i + 1) as u32);
+            }
+        }
+        Self {
+            stack: vec![Vec::new()], // module-level collector
+            line_starts,
+        }
+    }
+
+    /// 1-based line containing byte offset `pos`.
+    fn line(&self, pos: usize) -> u32 {
+        self.line_starts
+            .partition_point(|&start| start as usize <= pos) as u32
+    }
+
+    /// The module-level node list (the single remaining collector).
+    fn finish(mut self) -> Vec<Node> {
+        self.stack.pop().expect("module collector")
+    }
+
+    /// Append a node to the current collector.
+    fn emit(&mut self, node: Node) {
+        self.stack.last_mut().expect("collector").push(node);
+    }
+
+    /// Run `f` against a fresh collector and return the nodes it gathered.
+    fn collect<F: FnOnce(&mut Self)>(&mut self, f: F) -> Vec<Node> {
+        self.stack.push(Vec::new());
+        f(self);
+        self.stack.pop().expect("collector")
+    }
+
+    /// Emit a `Function` whose body is whatever `walk` gathers in a sub-traversal.
+    fn emit_function<F: FnOnce(&mut Self)>(
+        &mut self,
+        name: String,
+        kind: &'static str,
+        line: u32,
+        walk: F,
+    ) {
+        let body = self.collect(walk);
+        self.emit(Node::Function {
+            name,
+            kind: kind.to_string(),
+            line,
+            body,
+        });
+    }
+
+    /// Visit every statement of a `StatementsNode` body (if present).
+    fn visit_stmts(&mut self, stmts: &Option<StatementsNode<'_>>) {
+        if let Some(stmts) = stmts {
+            for s in &stmts.body() {
+                self.visit(&s);
+            }
+        }
+    }
+
+    // ---- branches ---------------------------------------------------------
+
+    /// Lower an `if` (or `elsif`) node to a `Branch`.
+    fn lower_if(&mut self, node: &IfNode) -> Node {
+        let test = self.collect(|b| b.visit(&node.predicate()));
+        let then = self.collect(|b| b.visit_stmts(&node.statements()));
+        let alternate = self.lower_subsequent(node.subsequent());
+        Node::Branch {
+            test,
+            then,
+            alternate,
+        }
+    }
+
+    /// Fold an `if` node's `subsequent` (the `elsif`/`else` tail) into the outer
+    /// branch's `alternate`: an `elsif` is a nested `Branch` (so it scores flat),
+    /// a plain `else` becomes a `Group`.
+    fn lower_subsequent(&mut self, subsequent: Option<PrismNode>) -> Option<Box<Node>> {
+        let node = subsequent?;
+        if let Some(elsif) = node.as_if_node() {
+            Some(Box::new(self.lower_if(&elsif)))
+        } else if let Some(els) = node.as_else_node() {
+            let stmts = els.statements();
+            Some(Box::new(Node::Group(
+                self.collect(|b| b.visit_stmts(&stmts)),
+            )))
+        } else {
+            // Defensive: any other tail shape scores as a flat `else`.
+            Some(Box::new(Node::Group(self.collect(|b| b.visit(&node)))))
+        }
+    }
+}
+
+impl<'pr> Visit<'pr> for Builder {
+    fn visit_if_node(&mut self, node: &IfNode<'pr>) {
+        // A keyword-less `IfNode` is the ternary `a ? b : c`: model it as a
+        // `Conditional` so the `:` branch is not counted as a second `else`.
+        if node.if_keyword_loc().is_none() {
+            let test = self.collect(|b| b.visit(&node.predicate()));
+            let then = self.collect(|b| b.visit_stmts(&node.statements()));
+            let alternate = self.collect(|b| {
+                if let Some(sub) = node.subsequent() {
+                    if let Some(els) = sub.as_else_node() {
+                        let stmts = els.statements();
+                        b.visit_stmts(&stmts);
+                    } else {
+                        b.visit(&sub);
+                    }
+                }
+            });
+            self.emit(Node::Conditional {
+                test,
+                then,
+                alternate,
+            });
+        } else {
+            let branch = self.lower_if(node);
+            self.emit(branch);
+        }
+    }
+
+    fn visit_unless_node(&mut self, node: &UnlessNode<'pr>) {
+        let test = self.collect(|b| b.visit(&node.predicate()));
+        let then = self.collect(|b| b.visit_stmts(&node.statements()));
+        let else_clause = node.else_clause();
+        let alternate = else_clause.map(|els| {
+            let stmts = els.statements();
+            Box::new(Node::Group(self.collect(|b| b.visit_stmts(&stmts))))
+        });
+        self.emit(Node::Branch {
+            test,
+            then,
+            alternate,
+        });
+    }
+
+    fn visit_while_node(&mut self, node: &WhileNode<'pr>) {
+        let body = self.collect(|b| {
+            b.visit(&node.predicate());
+            b.visit_stmts(&node.statements());
+        });
+        self.emit(Node::Loop { body });
+    }
+
+    fn visit_until_node(&mut self, node: &UntilNode<'pr>) {
+        let body = self.collect(|b| {
+            b.visit(&node.predicate());
+            b.visit_stmts(&node.statements());
+        });
+        self.emit(Node::Loop { body });
+    }
+
+    fn visit_for_node(&mut self, node: &ForNode<'pr>) {
+        let body = self.collect(|b| {
+            b.visit(&node.collection());
+            b.visit_stmts(&node.statements());
+        });
+        self.emit(Node::Loop { body });
+    }
+
+    fn visit_case_node(&mut self, node: &CaseNode<'pr>) {
+        // The subject runs at the case's own level, before its `when` arms.
+        if let Some(pred) = node.predicate() {
+            self.visit(&pred);
+        }
+        let mut cases = Vec::new();
+        for cond in &node.conditions() {
+            if let Some(when) = cond.as_when_node() {
+                let stmts = when.statements();
+                let body = self.collect(|b| {
+                    for c in &when.conditions() {
+                        b.visit(&c);
+                    }
+                    b.visit_stmts(&stmts);
+                });
+                cases.push(SwitchCase {
+                    is_default: false,
+                    body,
+                });
+            }
+        }
+        if let Some(els) = node.else_clause() {
+            let stmts = els.statements();
+            cases.push(SwitchCase {
+                is_default: true,
+                body: self.collect(|b| b.visit_stmts(&stmts)),
+            });
+        }
+        self.emit(Node::Switch { cases });
+    }
+
+    fn visit_case_match_node(&mut self, node: &CaseMatchNode<'pr>) {
+        // `case … in …` pattern matching: each `in` clause is a decision point.
+        if let Some(pred) = node.predicate() {
+            self.visit(&pred);
+        }
+        let mut cases = Vec::new();
+        for cond in &node.conditions() {
+            if let Some(in_clause) = cond.as_in_node() {
+                let stmts = in_clause.statements();
+                let body = self.collect(|b| {
+                    b.visit(&in_clause.pattern());
+                    b.visit_stmts(&stmts);
+                });
+                cases.push(SwitchCase {
+                    is_default: false,
+                    body,
+                });
+            }
+        }
+        if let Some(els) = node.else_clause() {
+            let stmts = els.statements();
+            cases.push(SwitchCase {
+                is_default: true,
+                body: self.collect(|b| b.visit_stmts(&stmts)),
+            });
+        }
+        self.emit(Node::Switch { cases });
+    }
+
+    fn visit_begin_node(&mut self, node: &BeginNode<'pr>) {
+        // The `begin` body, `else`, and `ensure` all run at the surrounding
+        // level; only each `rescue` clause is a decision point.
+        self.visit_stmts(&node.statements());
+        let mut rescue = node.rescue_clause();
+        while let Some(clause) = rescue {
+            let stmts = clause.statements();
+            let body = self.collect(|b| {
+                for ex in &clause.exceptions() {
+                    b.visit(&ex);
+                }
+                b.visit_stmts(&stmts);
+            });
+            self.emit(Node::Catch { body });
+            rescue = clause.subsequent();
+        }
+        if let Some(els) = node.else_clause() {
+            let stmts = els.statements();
+            self.visit_stmts(&stmts);
+        }
+        if let Some(ens) = node.ensure_clause() {
+            let stmts = ens.statements();
+            self.visit_stmts(&stmts);
+        }
+    }
+
+    fn visit_rescue_modifier_node(&mut self, node: &RescueModifierNode<'pr>) {
+        // `x rescue y`: `x` runs at the surrounding level, `y` is the handler.
+        self.visit(&node.expression());
+        let body = self.collect(|b| b.visit(&node.rescue_expression()));
+        self.emit(Node::Catch { body });
+    }
+
+    fn visit_and_node(&mut self, node: &AndNode<'pr>) {
+        let mut operands = Vec::new();
+        collect_logical(self, node.as_node(), LogicalOp::And, &mut operands);
+        self.emit(Node::Logical {
+            op: LogicalOp::And,
+            operands,
+        });
+    }
+
+    fn visit_or_node(&mut self, node: &OrNode<'pr>) {
+        let mut operands = Vec::new();
+        collect_logical(self, node.as_node(), LogicalOp::Or, &mut operands);
+        self.emit(Node::Logical {
+            op: LogicalOp::Or,
+            operands,
+        });
+    }
+
+    fn visit_def_node(&mut self, node: &DefNode<'pr>) {
+        let name = constant_name(node.name().as_slice(), "<method>");
+        let line = self.line(node.location().start_offset());
+        let body = node.body();
+        self.emit_function(name, "method", line, |b| {
+            if let Some(body) = &body {
+                b.visit(body);
+            }
+        });
+    }
+
+    fn visit_block_node(&mut self, node: &BlockNode<'pr>) {
+        // Reached only for blocks not attached to a plain call (e.g. `super`);
+        // call-attached blocks are handled in `visit_call_node` so they can
+        // borrow the method name.
+        let line = self.line(node.location().start_offset());
+        let body = node.body();
+        self.emit_function("<block>".to_string(), "block", line, |b| {
+            if let Some(body) = &body {
+                b.visit(body);
+            }
+        });
+    }
+
+    fn visit_lambda_node(&mut self, node: &LambdaNode<'pr>) {
+        let line = self.line(node.location().start_offset());
+        let body = node.body();
+        self.emit_function("<lambda>".to_string(), "lambda", line, |b| {
+            if let Some(body) = &body {
+                b.visit(body);
+            }
+        });
+    }
+
+    fn visit_call_node(&mut self, node: &CallNode<'pr>) {
+        let name = constant_name(node.name().as_slice(), "<call>");
+        // Safe-navigation (`a&.b`) is still a call for recursion purposes.
+        self.emit(Node::Call {
+            callee: Some(name.clone()),
+        });
+
+        // Manually walk the children so we can turn a `{ }` / `do…end` block into
+        // its own `Function` unit named after this method (and not double-visit).
+        if let Some(recv) = node.receiver() {
+            self.visit(&recv);
+        }
+        if let Some(args) = node.arguments() {
+            for a in &args.arguments() {
+                self.visit(&a);
+            }
+        }
+        if let Some(block) = node.block() {
+            if let Some(block) = block.as_block_node() {
+                let line = self.line(block.location().start_offset());
+                let body = block.body();
+                self.emit_function(name, "block", line, |b| {
+                    if let Some(body) = &body {
+                        b.visit(body);
+                    }
+                });
+            } else {
+                // A `&blk` block argument: just an expression to recurse into.
+                self.visit(&block);
+            }
+        }
+    }
+}
+
+/// Flatten a run of like logical operators into `operands`. A same-operator
+/// child recurses (folding `a && b && c` into one run); a different operator
+/// nests as its own `Logical`; any other expression becomes a `Group` of its
+/// sub-nodes. Single-statement parentheses are transparent (`a && (b && c)`
+/// folds to one run).
+fn collect_logical<'pr>(
+    builder: &mut Builder,
+    node: PrismNode<'pr>,
+    op: LogicalOp,
+    operands: &mut Vec<Node>,
+) {
+    let node = unwrap_parens(node);
+    match logical_of(&node) {
+        Some((side_op, left, right)) if side_op == op => {
+            collect_logical(builder, left, op, operands);
+            collect_logical(builder, right, op, operands);
+        }
+        Some((side_op, left, right)) => {
+            let mut sub = Vec::new();
+            collect_logical(builder, left, side_op, &mut sub);
+            collect_logical(builder, right, side_op, &mut sub);
+            operands.push(Node::Logical {
+                op: side_op,
+                operands: sub,
+            });
+        }
+        None => {
+            let nodes = builder.collect(|b| b.visit(&node));
+            operands.push(Node::Group(nodes));
+        }
+    }
+}
+
+/// The normalized operator and operands of a logical node (`&&`/`and` → `And`,
+/// `||`/`or` → `Or`), if it is one.
+fn logical_of<'pr>(node: &PrismNode<'pr>) -> Option<(LogicalOp, PrismNode<'pr>, PrismNode<'pr>)> {
+    if let Some(n) = node.as_and_node() {
+        Some((LogicalOp::And, n.left(), n.right()))
+    } else {
+        node.as_or_node()
+            .map(|n| (LogicalOp::Or, n.left(), n.right()))
+    }
+}
+
+/// Follow single-statement `( … )` wrappers to the inner expression.
+fn unwrap_parens<'pr>(node: PrismNode<'pr>) -> PrismNode<'pr> {
+    if let Some(parens) = node.as_parentheses_node()
+        && let Some(body) = parens.body()
+        && let Some(stmts) = body.as_statements_node()
+    {
+        let mut iter = stmts.body().iter();
+        let (first, second) = (iter.next(), iter.next());
+        if let (Some(only), None) = (first, second) {
+            return unwrap_parens(only);
+        }
+    }
+    node
+}
+
+/// A constant/identifier name as UTF-8, or `default` if it is empty/undecodable.
+fn constant_name(bytes: &[u8], default: &str) -> String {
+    if bytes.is_empty() {
+        default.to_string()
+    } else {
+        String::from_utf8_lossy(bytes).into_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cccc_core::report::FunctionReport;
+
+    fn analyze(src: &str) -> FileReport {
+        analyze_source(Path::new("test.rb"), src)
+    }
+
+    fn find<'a>(fns: &'a [FunctionReport], name: &str) -> Option<&'a FunctionReport> {
+        for f in fns {
+            if f.name == name {
+                return Some(f);
+            }
+            if let Some(found) = find(&f.children, name) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn cognitive_of(src: &str, name: &str) -> u32 {
+        find(&analyze(src).functions, name)
+            .unwrap_or_else(|| panic!("function {name} not found"))
+            .cognitive
+    }
+
+    fn cyclomatic_of(src: &str, name: &str) -> u32 {
+        find(&analyze(src).functions, name)
+            .unwrap_or_else(|| panic!("function {name} not found"))
+            .cyclomatic
+    }
+
+    #[test]
+    fn nested_if_adds_nesting() {
+        let src = r#"
+            def f(a, b, c)
+              if a
+                if b
+                  if c
+                  end
+                end
+              end
+            end
+        "#;
+        // if(+1) + nested if(+2) + nested if(+3) = 6
+        assert_eq!(cognitive_of(src, "f"), 6);
+        // base 1 + three ifs = 4
+        assert_eq!(cyclomatic_of(src, "f"), 4);
+    }
+
+    #[test]
+    fn elsif_else_are_flat() {
+        let src = r#"
+            def f(a, b)
+              if a
+              elsif b
+              else
+              end
+            end
+        "#;
+        // if(+1) + elsif(+1 flat) + else(+1 flat) = 3
+        assert_eq!(cognitive_of(src, "f"), 3);
+        // base 1 + if + elsif = 3 (else is not a decision point)
+        assert_eq!(cyclomatic_of(src, "f"), 3);
+    }
+
+    #[test]
+    fn unless_with_else_scores_like_a_branch() {
+        let src = r#"
+            def f(a)
+              unless a
+                1
+              else
+                2
+              end
+            end
+        "#;
+        // unless(+1) + else(+1 flat) = 2
+        assert_eq!(cognitive_of(src, "f"), 2);
+        assert_eq!(cyclomatic_of(src, "f"), 2);
+    }
+
+    #[test]
+    fn loops_all_count() {
+        let src = r#"
+            def f(a, items)
+              while a
+              end
+              for i in items
+              end
+              until a
+              end
+            end
+        "#;
+        // three loops, each +1 at nesting 0
+        assert_eq!(cognitive_of(src, "f"), 3);
+        // base 1 + three loops = 4
+        assert_eq!(cyclomatic_of(src, "f"), 4);
+    }
+
+    #[test]
+    fn modifier_while_is_a_loop() {
+        let src = r#"
+            def f(a)
+              x = 0
+              x += 1 while a
+            end
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 1);
+    }
+
+    #[test]
+    fn logical_sequences_fold_by_operator() {
+        let src = r#"
+            def f(a, b, c, d)
+              if a && b && c || d
+              end
+            end
+        "#;
+        // if(+1) + && run(+1) + || run(+1) = 3
+        assert_eq!(cognitive_of(src, "f"), 3);
+        // base 1 + if 1 + (&& 3 operands => +2) + (|| 2 operands => +1) = 5
+        assert_eq!(cyclomatic_of(src, "f"), 5);
+    }
+
+    #[test]
+    fn keyword_and_folds_with_symbol_and() {
+        let src = r#"
+            def f(a, b, c)
+              if a && b and c
+              end
+            end
+        "#;
+        // `&&` and `and` are the same normalized operator → one folded run.
+        // if(+1) + and-run(+1) = 2
+        assert_eq!(cognitive_of(src, "f"), 2);
+    }
+
+    #[test]
+    fn ternary_is_a_conditional() {
+        let src = r#"
+            def f(a)
+              a ? 1 : 2
+            end
+        "#;
+        // A ternary is a single increment (the `:` is not a second `else`).
+        assert_eq!(cognitive_of(src, "f"), 1);
+        assert_eq!(cyclomatic_of(src, "f"), 2);
+    }
+
+    #[test]
+    fn case_when_scores_like_a_switch() {
+        let src = r#"
+            def f(x)
+              case x
+              when 1 then "one"
+              when 2 then "a couple"
+              else "lots"
+              end
+            end
+        "#;
+        // case(+1) = 1
+        assert_eq!(cognitive_of(src, "f"), 1);
+        // base 1 + 2 non-default whens = 3
+        assert_eq!(cyclomatic_of(src, "f"), 3);
+    }
+
+    #[test]
+    fn case_in_pattern_match_scores_like_a_switch() {
+        let src = r#"
+            def f(x)
+              case x
+              in Integer then 1
+              in String then 2
+              else 3
+              end
+            end
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 1);
+        // base 1 + 2 non-default ins = 3
+        assert_eq!(cyclomatic_of(src, "f"), 3);
+    }
+
+    #[test]
+    fn rescue_clause_counts() {
+        let src = r#"
+            def f
+              begin
+                risky
+              rescue => e
+                handle
+              end
+            end
+        "#;
+        // rescue(+1) = 1
+        assert_eq!(cognitive_of(src, "f"), 1);
+        // base 1 + rescue 1 = 2
+        assert_eq!(cyclomatic_of(src, "f"), 2);
+    }
+
+    #[test]
+    fn implicit_begin_rescue_in_def_counts() {
+        let src = r#"
+            def f
+              risky
+            rescue
+              handle
+            end
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 1);
+    }
+
+    #[test]
+    fn modifier_rescue_counts() {
+        let src = r#"
+            def f
+              risky rescue nil
+            end
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 1);
+    }
+
+    #[test]
+    fn recursion_adds_one_per_call() {
+        let src = r#"
+            def fib(n)
+              return n if n < 2
+              fib(n - 1) + fib(n - 2)
+            end
+        "#;
+        // modifier if(+1) + two recursive calls(+2) = 3
+        assert_eq!(cognitive_of(src, "fib"), 3);
+        assert_eq!(find(&analyze(src).functions, "fib").unwrap().kind, "method");
+    }
+
+    #[test]
+    fn method_recursion_via_self_is_detected() {
+        let src = r#"
+            class S
+              def walk(n)
+                if n == 0
+                  0
+                else
+                  self.walk(n - 1)
+                end
+              end
+            end
+        "#;
+        // if(+1) + else(+1) + recursion(+1) = 3
+        assert_eq!(cognitive_of(src, "walk"), 3);
+        assert_eq!(
+            find(&analyze(src).functions, "walk").unwrap().kind,
+            "method"
+        );
+    }
+
+    #[test]
+    fn block_is_its_own_unit_named_after_the_method() {
+        let src = r#"
+            def host(xs)
+              xs.each do |x|
+                if x && x
+                  1
+                end
+              end
+            end
+        "#;
+        // host owns no structural complexity; the block does.
+        assert_eq!(cognitive_of(src, "host"), 0);
+        // if(+1) + && run(+1) = 2
+        assert_eq!(cognitive_of(src, "each"), 2);
+        assert_eq!(find(&analyze(src).functions, "each").unwrap().kind, "block");
+    }
+
+    #[test]
+    fn lambda_is_its_own_unit() {
+        let src = r#"
+            def host
+              f = ->(x) { x && x }
+              f
+            end
+        "#;
+        assert_eq!(cognitive_of(src, "host"), 0);
+        // && run(+1) = 1
+        assert_eq!(cognitive_of(src, "<lambda>"), 1);
+        assert_eq!(
+            find(&analyze(src).functions, "<lambda>").unwrap().kind,
+            "lambda"
+        );
+    }
+
+    #[test]
+    fn singleton_method_is_a_unit() {
+        let src = r#"
+            def self.create(x)
+              if x
+                1
+              end
+            end
+        "#;
+        assert_eq!(cognitive_of(src, "create"), 1);
+    }
+
+    #[test]
+    fn file_total_sums_all_methods() {
+        let src = r#"
+            def a(x)
+              if x
+              end
+            end
+            def b(y)
+              if y
+              end
+            end
+        "#;
+        assert_eq!(analyze(src).cognitive, 2);
+    }
+
+    #[test]
+    fn parse_error_is_reported() {
+        // Prism is fault-tolerant: it still yields a (partial) AST but surfaces a
+        // diagnostic for the broken input.
+        let (_nodes, errors) = to_ir(Path::new("bad.rb"), "def f(\n");
+        assert!(!errors.is_empty());
+    }
+}

--- a/crates/cccc-rb/src/lib.rs
+++ b/crates/cccc-rb/src/lib.rs
@@ -28,8 +28,11 @@
 //! - `def` (incl. `def self.m`) → [`Node::Function`] (`"method"`); a block
 //!   (`{ }` / `do…end`) → `"block"`; a `-> { }` lambda → `"lambda"`. Each is its
 //!   own unit (nesting resets), matching how the ES/PHP adapters treat
-//!   arrows/closures. A block borrows the name of the method it is passed to
-//!   (`xs.each { }` → `each`).
+//!   arrows/closures. Blocks and lambdas are anonymous (`<block>` / `<lambda>`),
+//!   like an unassigned ES/PHP callback — deliberately *not* named after the
+//!   method they are passed to, so a DSL block that calls the same method again
+//!   (nested `describe`/`context`, Rails `namespace`, …) is not mistaken for
+//!   recursion.
 //! - `if` / `elsif` / `else` and `unless` → [`Node::Branch`] (chaining `elsif` as
 //!   a nested `Branch` so it scores flat). The ternary `a ? b : c` is a keyword-
 //!   less `IfNode`, lowered to [`Node::Conditional`] so its `else` is not a second
@@ -384,8 +387,7 @@ impl<'pr> Visit<'pr> for Builder {
 
     fn visit_block_node(&mut self, node: &BlockNode<'pr>) {
         // Reached only for blocks not attached to a plain call (e.g. `super`);
-        // call-attached blocks are handled in `visit_call_node` so they can
-        // borrow the method name.
+        // call-attached blocks are handled in `visit_call_node`.
         let line = self.line(node.location().start_offset());
         let body = node.body();
         self.emit_function("<block>".to_string(), "block", line, |b| {
@@ -408,12 +410,10 @@ impl<'pr> Visit<'pr> for Builder {
     fn visit_call_node(&mut self, node: &CallNode<'pr>) {
         let name = constant_name(node.name().as_slice(), "<call>");
         // Safe-navigation (`a&.b`) is still a call for recursion purposes.
-        self.emit(Node::Call {
-            callee: Some(name.clone()),
-        });
+        self.emit(Node::Call { callee: Some(name) });
 
         // Manually walk the children so we can turn a `{ }` / `do…end` block into
-        // its own `Function` unit named after this method (and not double-visit).
+        // its own `Function` unit (and not double-visit it via the default walk).
         if let Some(recv) = node.receiver() {
             self.visit(&recv);
         }
@@ -426,7 +426,12 @@ impl<'pr> Visit<'pr> for Builder {
             if let Some(block) = block.as_block_node() {
                 let line = self.line(block.location().start_offset());
                 let body = block.body();
-                self.emit_function(name, "block", line, |b| {
+                // A block is anonymous (like an ES/PHP callback): name it
+                // `<block>`, not after the method it is passed to. Borrowing the
+                // method name would make a DSL block that contains sibling calls
+                // to the same method (nested `describe`/`context`, Rails
+                // `namespace`, …) look self-recursive and inflate its score.
+                self.emit_function("<block>".to_string(), "block", line, |b| {
                     if let Some(body) = &body {
                         b.visit(body);
                     }
@@ -765,7 +770,7 @@ mod tests {
     }
 
     #[test]
-    fn block_is_its_own_unit_named_after_the_method() {
+    fn block_is_its_own_anonymous_unit() {
         let src = r#"
             def host(xs)
               xs.each do |x|
@@ -778,8 +783,28 @@ mod tests {
         // host owns no structural complexity; the block does.
         assert_eq!(cognitive_of(src, "host"), 0);
         // if(+1) + && run(+1) = 2
-        assert_eq!(cognitive_of(src, "each"), 2);
-        assert_eq!(find(&analyze(src).functions, "each").unwrap().kind, "block");
+        assert_eq!(cognitive_of(src, "<block>"), 2);
+        assert_eq!(
+            find(&analyze(src).functions, "<block>").unwrap().kind,
+            "block"
+        );
+    }
+
+    #[test]
+    fn dsl_block_calling_its_own_method_is_not_recursion() {
+        // A block passed to `describe` that itself calls `describe`/`context`
+        // must not be scored as self-recursion (the block is anonymous, not a
+        // method named `describe`).
+        let src = r#"
+            describe "outer" do
+              describe "a" do
+              end
+              context "b" do
+              end
+            end
+        "#;
+        // The outer block has no branches/loops/logic → cognitive 0.
+        assert_eq!(cognitive_of(src, "<block>"), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds a **Ruby** front-end to `cccc` (`--lang ruby`, alias `rb`, extension `.rb`), in the same adapter shape as the existing four languages — same engine, flags, and output. Built on [ruby-prism](https://docs.rs/ruby-prism), the Rust binding to Ruby's official [Prism](https://github.com/ruby/prism) parser.

## New crate

| Crate | Role |
|-------|------|
| `cccc-rb` | Ruby adapter library: lowers the ruby-prism AST into `cccc-core`'s IR. Depends only on `cccc-core` + `ruby-prism`, no CLI deps. Registered in `cccc-cli`'s `lang::LANGUAGES`. |

Lowering is driven by Prism's `Visit` full-traversal trait (same collector-stack approach as `cccc-php`), so a construct in an unexpected position is never silently missed.

## Ruby → IR mapping

| Ruby | IR |
|------|-----|
| `def` / `def self.m` / blocks / lambdas | `Function` (each its own unit; blocks/lambdas are anonymous) |
| `if` / `elsif` / `else` / `unless` (+ modifier forms) | `Branch` (`elsif` nested → flat) |
| ternary `a ? b : c` (keyword-less `IfNode`) | `Conditional` (so `:` isn't a 2nd increment) |
| `while` / `until` / `for` (+ modifier forms) | `Loop` |
| `case`/`when`, `case`/`in` (pattern matching) | `Switch` |
| `rescue`, modifier `x rescue y` | `Catch` |
| `&&` / `and` / `\|\|` / `or` | folded `Logical` |
| calls | `Call` (recursion detection) |

Ruby has no labelled `break`/`next`, so those never add a cognitive point.

## Parser selection

`ruby-prism` wraps **Prism**, Ruby's official parser, for accuracy and long-term maintenance, and it ships the `Visit` trait we drive lowering from. The trade-off: unlike the pure-Rust adapters, ruby-prism is an FFI binding that builds Prism's **vendored C sources** via bindgen, so building `cccc-rb` needs a C99 compiler and libclang. CI handles this on every release target — musl cross-compiles with `cargo-zigbuild` (zig supplies the target C toolchain), Windows points bindgen at the runner's LLVM libclang, and a new `cross-build.yml` validates all targets on every PR.

## Testing

- **21 adapter unit tests**, anchored on the SonarSource examples plus Ruby-specific constructs.
- A `sample.rb` fixture wired into the cross-language smoke test (`sum_of_primes` = cognitive 7 / cyclomatic 4), and the CLI integration tests.
- `cargo fmt` / `clippy -D warnings` / `cargo test` all green; the cross-build matrix (5 targets) is green on the PR.

## Real-world results

Ran against real projects (first-party source, vendored deps excluded):

| Project | Files | Functions | Parse errors |
|---------|------:|----------:|-------------:|
| liquid | 109 | 1,696 | 0 |
| kramdown | 63 | 881 | 0 |
| mail | 196 | 3,796 | 0 |
| faraday | 71 | 2,101 | 0 |
| rubocop-ast | 171 | 6,897 | 0 |
| haml | 98 | 1,656 | 0 |
| slim | 75 | 786 | 0 |

Including vendored gems (parser, rdoc, prism itself, …), the tool lowered **~14,000 files / ~230,000 functions without a single crash**.

### Validity check

- **Parse errors** appeared only in files that genuinely aren't valid standalone Ruby — intentionally-broken RuboCop test fixtures and Rails ERB templates (`class <%= ... %>`) — matching Prism's own judgment.
- **Hotspot vs. source**: faraday's `build_exclusive_url` measured cognitive 13 / cyclomatic 14; hand-counting the source (6 `if`s + 1 ternary + 4 `&&` + 2 `||`) reproduces both exactly.
- The audit also caught a real scoring bug: naming a block after the method it is passed to made DSL blocks (nested `describe`/`context`, Rails `namespace`) look self-recursive. Fixed by making blocks/lambdas anonymous, with a regression test (see the 2nd commit).