### PR TITLE
feat: Zig adapter (cccc-zig)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "cccc-rb",
  "cccc-rs",
  "cccc-scheme",
+ "cccc-zig",
  "clap",
  "globset",
  "ignore",
@@ -322,6 +323,14 @@ name = "cccc-scheme"
 version = "1.2.0"
 dependencies = [
  "cccc-lisp-kit",
+]
+
+[[package]]
+name = "cccc-zig"
+version = "1.2.0"
+dependencies = [
+ "cccc-core",
+ "zigsyn",
 ]
 
 [[package]]
@@ -1667,6 +1676,17 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "zigsyn"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c2e53e0acf479814aa8b9e94ccfe0cce54151f1354df4537b318a344d38bcb"
+dependencies = [
+ "anyhow",
+ "strum",
+ "thiserror",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/cccc-lisp",
     "crates/cccc-kt",
     "crates/cccc-py",
+    "crates/cccc-zig",
 ]
 resolver = "2"
 
@@ -37,6 +38,7 @@ cccc-lisp-kit = { path = "crates/cccc-lisp-kit", version = "1.2.0" }
 cccc-lisp = { path = "crates/cccc-lisp", version = "1.2.0" }
 cccc-kt = { path = "crates/cccc-kt", version = "1.2.0" }
 cccc-py = { path = "crates/cccc-py", version = "1.2.0" }
+cccc-zig = { path = "crates/cccc-zig", version = "1.2.0" }
 serde = { version = "1", features = ["derive"] }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
   - **Python** (`--lang python`), via the official
     [tree-sitter-python](https://github.com/tree-sitter/tree-sitter-python)
     grammar. Analyzes `.py`, `.pyi`.
+  - **Zig** (`--lang zig`), via the pure-Rust
+    [zigsyn](https://docs.rs/zigsyn) parser. Analyzes `.zig`.
 - A Rust library for calculating cognitive and cyclomatic complexity in a language-agnostic way
 
 ## Workspace layout
@@ -54,6 +56,7 @@ library and extended to other languages:
 | [`cccc-scheme`](crates/cccc-scheme) | Scheme (R7RS-small) adapter **library**: lowers the [lispexp](https://docs.rs/lispexp) S-expression tree into `cccc-core`'s IR. Depends only on `cccc-core` + lispexp (pure Rust) — **no CLI dependencies**. |
 | [`cccc-kt`](crates/cccc-kt) | Kotlin adapter **library**: lowers the [exoego/tree-sitter-kotlin](https://github.com/exoego/tree-sitter-kotlin) CST into `cccc-core`'s IR. Depends only on `cccc-core` + tree-sitter + the Kotlin grammar — **no CLI dependencies**. Note: the grammar ships C source compiled by `cc`, so building this crate needs a C compiler (but not libclang, unlike `cccc-rb`). |
 | [`cccc-py`](crates/cccc-py) | Python adapter **library**: lowers the official [tree-sitter-python](https://github.com/tree-sitter/tree-sitter-python) CST into `cccc-core`'s IR. Depends only on `cccc-core` + tree-sitter + the Python grammar — **no CLI dependencies**. Like `cccc-kt`, the grammar's C source is compiled by `cc`, so building needs a C compiler (no libclang). |
+| [`cccc-zig`](crates/cccc-zig) | Zig adapter **library**: lowers the pure-Rust [zigsyn](https://docs.rs/zigsyn) AST into `cccc-core`'s IR. Depends only on `cccc-core` + zigsyn — **no CLI dependencies or C toolchain**. |
 
 Each adapter is a standalone library so that a consumer who only wants the
 metrics pulls in just that adapter (+ `cccc-core` + its parser), never clap /
@@ -66,9 +69,9 @@ it with one entry in `cccc-cli`'s `lang::LANGUAGES` (and add the dependency) —
 no new binary, and no reimplementing the metrics or the CLI. `cccc-es` (oxc),
 `cccc-rs` (syn), `cccc-go` (gosyn), `cccc-php` (php-rs-parser), `cccc-rb`
 (ruby-prism), `cccc-kt` / `cccc-py` (tree-sitter), `cccc-scheme` (lispexp), `cccc-clojure`
-(lispexp), and `cccc-lisp` (lispexp, Common Lisp / Emacs Lisp / …) are the
-reference adapters: same shape, different parser. The Lisp-family adapters share
-their lowering skeleton via `cccc-lisp-kit`.
+(lispexp), `cccc-lisp` (lispexp, Common Lisp / Emacs Lisp / …), and `cccc-zig`
+(zigsyn) are the reference adapters: same shape, different parser. The
+Lisp-family adapters share their lowering skeleton via `cccc-lisp-kit`.
 
 **See [docs/ADDING_A_LANGUAGE.md](docs/ADDING_A_LANGUAGE.md) for the full
 step-by-step guide**, including the IR-node reference table, the
@@ -350,3 +353,10 @@ nodes. Comprehensions and generator expressions score like the written-out
 loop: each `for` clause is a loop and each `if` clause a branch, nested
 left-to-right. Python has no labelled `break`/`continue` and no `??`; `not`
 adds nothing.
+
+For **Zig** (`--lang zig`): named `fn` declarations and `test` blocks are the
+function-like units; `if`/`else if`/`else`, `while`/`for` (a loop's `else`
+branch runs at the surrounding level), `switch` (an `else` prong is the
+non-decision `default` arm), `catch` handlers, labelled `break`/`continue`, and
+`and`/`or` map to the corresponding nodes. `orelse` folds as a coalescing run.
+Zig has no ternary expression; `if` is already an expression.

--- a/crates/cccc-cli/Cargo.toml
+++ b/crates/cccc-cli/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "The unified cccc binary: one CLI that measures cognitive/cyclomatic complexity across every bundled language (ECMAScript/TypeScript, Rust, Go, PHP, Ruby, Kotlin, Python)"
+description = "The unified cccc binary: one CLI that measures cognitive/cyclomatic complexity across every bundled language (ECMAScript/TypeScript, Rust, Go, PHP, Ruby, Kotlin, Python, Zig)"
 
 [[bin]]
 name = "cccc"
@@ -24,6 +24,7 @@ cccc-lisp = { workspace = true }
 cccc-clojure = { workspace = true }
 cccc-kt = { workspace = true }
 cccc-py = { workspace = true }
+cccc-zig = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 globset = "0.4"
 ignore = "0.4"

--- a/crates/cccc-cli/src/lang.rs
+++ b/crates/cccc-cli/src/lang.rs
@@ -100,6 +100,12 @@ pub const LANGUAGES: &[Language] = &[
         exts: cccc_py::DEFAULT_EXTS,
         analyze: cccc_py::analyze_source,
     },
+    Language {
+        name: "zig",
+        aliases: &[],
+        exts: cccc_zig::DEFAULT_EXTS,
+        analyze: cccc_zig::analyze_source,
+    },
 ];
 
 /// Resolve the active languages from an `include` (`--lang`) and an `exclude`
@@ -257,6 +263,7 @@ mod tests {
                 "clojure".to_string(),
                 "kotlin".to_string(),
                 "python".to_string(),
+                "zig".to_string(),
             ]),
         )
         .unwrap();
@@ -296,6 +303,7 @@ mod tests {
         let map = build_dispatch(&all, &BTreeMap::new());
         for key in [
             "ts", "rs", "go", "php", "rb", "scm", "lisp", "el", "clj", "kt", "kts", "py", "pyi",
+            "zig",
         ] {
             assert!(map.contains_key(key), "missing dispatch for .{key}");
         }

--- a/crates/cccc-cli/tests/cli.rs
+++ b/crates/cccc-cli/tests/cli.rs
@@ -242,7 +242,7 @@ fn analyzes_all_languages_in_one_run() {
     // The fixtures dir holds one file per language; a single run dispatches each
     // by extension and reports them all together.
     let v = json(&["tests/fixtures"]);
-    assert_eq!(v["summary"]["file_count"], 11);
+    assert_eq!(v["summary"]["file_count"], 12);
     let paths: Vec<String> = v["files"]
         .as_array()
         .unwrap()
@@ -261,6 +261,7 @@ fn analyzes_all_languages_in_one_run() {
         "sample.clj",
         "sample.kt",
         "sample.py",
+        "sample.zig",
     ] {
         assert!(paths.iter().any(|p| p.ends_with(ext)), "missing {ext}");
     }
@@ -293,11 +294,10 @@ fn unknown_lang_is_an_error() {
 
 #[test]
 fn exclude_lang_drops_a_language() {
-    // All languages minus Go, PHP, Ruby, Scheme, Common Lisp, Emacs Lisp and Clojure leaves the
-    // .ts and .rs fixtures.
+    // Excluding every language except ES and Rust leaves the .ts and .rs fixtures.
     let v = json(&[
         "--exclude-lang",
-        "go,php,ruby,scheme,commonlisp,emacslisp,clojure,kotlin,python",
+        "go,php,ruby,scheme,commonlisp,emacslisp,clojure,kotlin,python,zig",
         "tests/fixtures",
     ]);
     let mut exts: Vec<String> = v["files"]
@@ -343,7 +343,7 @@ fn excluding_every_language_is_an_error() {
         .unwrap()
         .args([
             "--exclude-lang",
-            "es,rust,go,php,ruby,scheme,commonlisp,emacslisp,clojure,kotlin,python",
+            "es,rust,go,php,ruby,scheme,commonlisp,emacslisp,clojure,kotlin,python,zig",
             "tests/fixtures",
         ])
         .assert()

--- a/crates/cccc-cli/tests/fixtures/sample.zig
+++ b/crates/cccc-cli/tests/fixtures/sample.zig
@@ -1,0 +1,12 @@
+pub fn sumOfPrimes(max: u32) u32 {
+    var total: u32 = 0;
+    outer: for (2..max) |i| {
+        for (2..i) |j| {
+            if (i % j == 0) {
+                continue :outer;
+            }
+        }
+        total += i;
+    }
+    return total;
+}

--- a/crates/cccc-cli/tests/lang_smoke.rs
+++ b/crates/cccc-cli/tests/lang_smoke.rs
@@ -84,3 +84,8 @@ fn kotlin_fixture_dispatches() {
 fn python_fixture_dispatches() {
     assert_sum_of_primes("sample.py", "sum_of_primes");
 }
+
+#[test]
+fn zig_fixture_dispatches() {
+    assert_sum_of_primes("sample.zig", "sumOfPrimes");
+}

--- a/crates/cccc-zig/Cargo.toml
+++ b/crates/cccc-zig/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cccc-zig"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Zig (zigsyn) adapter that lowers source into the cccc-core complexity IR"
+
+[dependencies]
+cccc-core = { workspace = true }
+zigsyn = "0.1"

--- a/crates/cccc-zig/src/lib.rs
+++ b/crates/cccc-zig/src/lib.rs
@@ -1,0 +1,751 @@
+//! Zig adapter: parses source with [zigsyn](https://docs.rs/zigsyn) and
+//! lowers the AST into the language-agnostic [`cccc_core::ir`].
+//!
+//! This crate is a pure library with no CLI dependencies. The unified `cccc`
+//! binary registers [`analyze_source`] and [`DEFAULT_EXTS`] and dispatches
+//! `.zig` files here.
+//!
+//! This crate contains **no scoring logic** — it recognizes named functions and
+//! test blocks, `if`/`else`, `while`/`for`, `switch`, `catch`, labelled jumps,
+//! `and`/`or`/`orelse`, and calls, then emits the corresponding IR nodes. All
+//! complexity rules remain in [`cccc_core::engine`].
+//!
+//! ## Why a hand-written traversal
+//!
+//! zigsyn does not expose a full-traversal visitor, so lowering follows the same
+//! approach as `cccc-go`: the node-bearing AST enums are matched exhaustively.
+//! Adding a node variant therefore produces a compile error until the adapter
+//! decides how to traverse it. A collector stack assembles nested IR bodies.
+
+use std::path::Path;
+
+use cccc_core::engine;
+use cccc_core::ir::{LogicalOp, Node, SwitchCase};
+use cccc_core::report::FileReport;
+use zigsyn::ast::*;
+use zigsyn::token::{Keyword, Token};
+
+/// File extensions analyzed by default (when `--ext` is not given).
+pub const DEFAULT_EXTS: &[&str] = &["zig"];
+
+/// Parse `source` and produce its [`FileReport`], scoring via the core engine.
+pub fn analyze_source(path: &Path, source: &str) -> FileReport {
+    let (nodes, parse_errors) = to_ir(path, source);
+    engine::analyze(&path.display().to_string(), &nodes, parse_errors)
+}
+
+/// Parse `source` and lower it to the complexity IR.
+///
+/// zigsyn parses a whole file at once and does not recover from syntax errors,
+/// so a parse failure yields an empty node list and one parser error string.
+pub fn to_ir(_path: &Path, source: &str) -> (Vec<Node>, Vec<String>) {
+    match zigsyn::parse_source(source) {
+        Ok(file) => {
+            let mut builder = Builder::new(file.line_info.clone());
+            builder.visit_file(&file);
+            (builder.finish(), Vec::new())
+        }
+        Err(error) => (Vec::new(), vec![error.to_string()]),
+    }
+}
+
+/// Assembles the IR while explicitly traversing zigsyn's node-bearing AST enums.
+struct Builder {
+    stack: Vec<Vec<Node>>,
+    line_starts: Vec<usize>,
+}
+
+impl Builder {
+    fn new(line_starts: Vec<usize>) -> Self {
+        Self {
+            stack: vec![Vec::new()],
+            line_starts,
+        }
+    }
+
+    fn finish(mut self) -> Vec<Node> {
+        self.stack.pop().expect("module collector")
+    }
+
+    fn line_of(&self, pos: usize) -> u32 {
+        self.line_starts.partition_point(|&start| start <= pos) as u32
+    }
+
+    fn emit(&mut self, node: Node) {
+        self.stack.last_mut().expect("collector").push(node);
+    }
+
+    fn collect(&mut self, walk: impl FnOnce(&mut Self)) -> Vec<Node> {
+        self.stack.push(Vec::new());
+        walk(self);
+        self.stack.pop().expect("collector")
+    }
+
+    fn emit_function(
+        &mut self,
+        name: String,
+        kind: &'static str,
+        line: u32,
+        walk: impl FnOnce(&mut Self),
+    ) {
+        let body = self.collect(walk);
+        self.emit(Node::Function {
+            name,
+            kind: kind.to_string(),
+            line,
+            body,
+        });
+    }
+
+    // ---- declarations -----------------------------------------------------
+
+    fn visit_file(&mut self, file: &File) {
+        for member in &file.members {
+            self.visit_container_member(member);
+        }
+    }
+
+    fn visit_container_member(&mut self, member: &ContainerMember) {
+        match member {
+            ContainerMember::Field(field) => self.visit_container_field(field),
+            ContainerMember::Fn(function) => self.visit_fn_decl(function),
+            ContainerMember::Var(var) => self.visit_var_decl(var),
+            ContainerMember::Test(test) => self.visit_test_decl(test),
+            ContainerMember::Comptime(comptime) => self.visit_block(&comptime.block),
+        }
+    }
+
+    fn visit_container_field(&mut self, field: &ContainerField) {
+        self.visit_optional_expression(field.ty.as_ref());
+        self.visit_optional_expression(field.align.as_ref());
+        self.visit_optional_expression(field.default.as_ref());
+    }
+
+    fn visit_fn_decl(&mut self, function: &FnDecl) {
+        let Some(body) = &function.body else {
+            self.visit_fn_signature(function);
+            return;
+        };
+        let name = function
+            .name
+            .as_ref()
+            .map(|name| name.name.clone())
+            .unwrap_or_else(|| "<function>".to_string());
+        let line = self.line_of(function.pos);
+        self.emit_function(name, "function", line, |builder| {
+            builder.visit_fn_signature(function);
+            builder.visit_block(body);
+        });
+    }
+
+    fn visit_fn_signature(&mut self, function: &FnDecl) {
+        for param in &function.params {
+            match &param.ty {
+                ParamType::AnyType(_) | ParamType::VarArgs(_) => {}
+                ParamType::Type(ty) => self.visit_expression(ty),
+            }
+        }
+        self.visit_optional_expression(function.align.as_ref());
+        self.visit_optional_expression(function.addrspace.as_ref());
+        self.visit_optional_expression(function.linksection.as_ref());
+        self.visit_optional_expression(function.callconv.as_ref());
+        self.visit_optional_expression(function.ret.as_deref());
+    }
+
+    fn visit_var_decl(&mut self, var: &VarDecl) {
+        for lhs in &var.lhs {
+            match lhs {
+                VarProtoOrExpr::VarProto { ty, .. } => self.visit_optional_expression(ty.as_ref()),
+                VarProtoOrExpr::Expr(expr) => self.visit_expression(expr),
+            }
+        }
+        self.visit_optional_expression(var.ty.as_ref());
+        self.visit_optional_expression(var.align.as_ref());
+        self.visit_optional_expression(var.addrspace.as_ref());
+        self.visit_optional_expression(var.linksection.as_ref());
+        self.visit_optional_expression(var.init.as_ref());
+    }
+
+    fn visit_test_decl(&mut self, test: &TestDecl) {
+        let name = test.name.as_ref().map_or_else(
+            || "<test>".to_string(),
+            |expr| format!("test {}", expression_label(expr)),
+        );
+        let line = self.line_of(test.pos);
+        self.emit_function(name, "test", line, |builder| {
+            builder.visit_optional_expression(test.name.as_ref());
+            builder.visit_block(&test.body);
+        });
+    }
+
+    // ---- statements -------------------------------------------------------
+
+    fn visit_block(&mut self, block: &Block) {
+        for statement in &block.statements {
+            self.visit_statement(statement);
+        }
+    }
+
+    fn visit_statement(&mut self, statement: &Statement) {
+        match statement {
+            Statement::Var(var) => self.visit_var_decl(var),
+            Statement::Defer(defer) => self.visit_statement(&defer.body),
+            Statement::If(if_) => {
+                let node = self.lower_if_statement(if_);
+                self.emit(node);
+            }
+            Statement::Loop(loop_) => self.visit_loop_statement(loop_),
+            Statement::Switch(switch) => self.visit_switch_expression(&switch.expr),
+            Statement::Suspend(suspend) => self.visit_statement(&suspend.body),
+            Statement::Nosuspend(nosuspend) => self.visit_statement(&nosuspend.body),
+            Statement::Comptime(comptime) => self.visit_statement(&comptime.body),
+            Statement::Assign(assign) => {
+                for lhs in &assign.lhs {
+                    self.visit_expression(lhs);
+                }
+                self.visit_expression(&assign.rhs);
+            }
+            Statement::Expr(expr) => self.visit_expression(&expr.expr),
+            Statement::Block(block) => self.visit_block(block),
+        }
+    }
+
+    fn lower_if_statement(&mut self, if_: &IfStmt) -> Node {
+        let test = self.collect(|builder| builder.visit_expression(&if_.condition));
+        let then = self.collect(|builder| builder.visit_statement(&if_.then_branch));
+        let alternate = if_.else_branch.as_deref().map(|branch| {
+            Box::new(match branch {
+                Statement::If(else_if) => self.lower_if_statement(else_if),
+                other => Node::Group(self.collect(|builder| builder.visit_statement(other))),
+            })
+        });
+        Node::Branch {
+            test,
+            then,
+            alternate,
+        }
+    }
+
+    fn visit_loop_statement(&mut self, loop_: &LoopStmt) {
+        let body = self.collect(|builder| {
+            match &loop_.kind {
+                LoopKind::While {
+                    condition,
+                    continue_expr,
+                    ..
+                } => {
+                    builder.visit_expression(condition);
+                    builder.visit_optional_expression(continue_expr.as_deref());
+                }
+                LoopKind::For { items, .. } => builder.visit_for_items(items),
+            }
+            builder.visit_statement(&loop_.body);
+        });
+        self.emit(Node::Loop { body });
+        if let Some(else_branch) = &loop_.else_branch {
+            self.visit_statement(else_branch);
+        }
+    }
+
+    // ---- expressions ------------------------------------------------------
+
+    fn visit_expression(&mut self, expression: &Expression) {
+        match expression {
+            Expression::Ident(_)
+            | Expression::BasicLit(_)
+            | Expression::MultilineStr(_)
+            | Expression::EnumLiteral(_)
+            | Expression::ErrorValue(_)
+            | Expression::ErrorSetDecl(_)
+            | Expression::Unreachable(_) => {}
+            Expression::BuiltinCall(call) => self.visit_expressions(&call.args),
+            Expression::AnonInit(init) => {
+                self.visit_expressions(&init.fields);
+                for entry in &init.entries {
+                    self.visit_init_entry(entry);
+                }
+            }
+            Expression::Grouped(inner)
+            | Expression::Comptime(inner)
+            | Expression::Nosuspend(inner)
+            | Expression::Resume(inner) => self.visit_expression(inner),
+            Expression::AnyframeType(anyframe) => {
+                self.visit_optional_expression(anyframe.result.as_deref())
+            }
+            Expression::Unary(unary) => self.visit_expression(&unary.expr),
+            Expression::Binary(binary) => self.visit_binary(binary),
+            Expression::Catch(catch) => self.visit_catch(catch),
+            Expression::Assign(assign) => {
+                self.visit_expressions(&assign.lhs);
+                self.visit_expression(&assign.rhs);
+            }
+            Expression::If(if_) => {
+                let node = self.lower_if_expression(if_);
+                self.emit(node);
+            }
+            Expression::While(while_) => self.visit_while_expression(while_),
+            Expression::For(for_) => self.visit_for_expression(for_),
+            Expression::Switch(switch) => self.visit_switch_expression(switch),
+            Expression::Block(block) => self.visit_block(block),
+            Expression::Break(break_) => {
+                self.emit(Node::Jump {
+                    labeled: break_.label.is_some(),
+                });
+                self.visit_optional_expression(break_.value.as_deref());
+            }
+            Expression::Continue(continue_) => {
+                self.emit(Node::Jump {
+                    labeled: continue_.label.is_some(),
+                });
+                self.visit_optional_expression(continue_.value.as_deref());
+            }
+            Expression::Return(return_) => self.visit_optional_expression(return_.value.as_deref()),
+            Expression::Asm(asm) => self.visit_asm(asm),
+            Expression::Call(call) => {
+                self.emit(Node::Call {
+                    callee: callee_name(&call.callee),
+                });
+                self.visit_expression(&call.callee);
+                self.visit_expressions(&call.args);
+            }
+            Expression::Index(index) => {
+                self.visit_expression(&index.expr);
+                self.visit_expression(&index.index);
+            }
+            Expression::Slice(slice) => {
+                self.visit_expression(&slice.expr);
+                self.visit_optional_expression(slice.start.as_deref());
+                self.visit_optional_expression(slice.end.as_deref());
+                self.visit_optional_expression(slice.sentinel.as_deref());
+            }
+            Expression::FieldAccess(field) => self.visit_expression(&field.expr),
+            Expression::Deref(deref) => self.visit_expression(&deref.expr),
+            Expression::Unwrap(unwrap) => self.visit_expression(&unwrap.expr),
+            Expression::InitList(init) => {
+                self.visit_expression(&init.ty);
+                for entry in &init.entries {
+                    self.visit_init_entry(entry);
+                }
+            }
+            Expression::Optional(optional) => self.visit_expression(&optional.child),
+            Expression::ErrorUnion(union) => {
+                self.visit_expression(&union.error);
+                self.visit_expression(&union.payload);
+            }
+            Expression::Pointer(pointer) => {
+                match &pointer.kind {
+                    PointerKind::One | PointerKind::Many | PointerKind::C => {}
+                    PointerKind::Sentinel(sentinel) => self.visit_expression(sentinel),
+                }
+                self.visit_pointer_modifiers(&pointer.modifiers);
+                self.visit_expression(&pointer.child);
+            }
+            Expression::SliceType(slice) => {
+                self.visit_optional_expression(slice.sentinel.as_deref());
+                self.visit_pointer_modifiers(&slice.modifiers);
+                self.visit_expression(&slice.child);
+            }
+            Expression::ArrayType(array) => {
+                self.visit_expression(&array.len);
+                self.visit_optional_expression(array.sentinel.as_deref());
+                self.visit_expression(&array.child);
+            }
+            Expression::Container(container) => {
+                if let Some(arg) = &container.arg {
+                    match arg {
+                        ContainerArg::Expr(expr) => self.visit_expression(expr),
+                        ContainerArg::Enum { tag_type, .. } => {
+                            self.visit_optional_expression(tag_type.as_deref())
+                        }
+                    }
+                }
+                for member in &container.members {
+                    self.visit_container_member(member);
+                }
+            }
+            Expression::FnProto(function) => self.visit_fn_signature(function),
+        }
+    }
+
+    // ---- control flow -----------------------------------------------------
+
+    fn lower_if_expression(&mut self, if_: &IfExpr) -> Node {
+        let test =
+            self.collect(|builder| builder.visit_optional_expression(if_.condition.as_deref()));
+        let then =
+            self.collect(|builder| builder.visit_optional_expression(if_.then_branch.as_deref()));
+        let alternate = if_.else_branch.as_deref().map(|branch| {
+            Box::new(match branch {
+                Expression::If(else_if) => self.lower_if_expression(else_if),
+                other => Node::Group(self.collect(|builder| builder.visit_expression(other))),
+            })
+        });
+        Node::Branch {
+            test,
+            then,
+            alternate,
+        }
+    }
+
+    fn visit_while_expression(&mut self, while_: &WhileExpr) {
+        let body = self.collect(|builder| {
+            builder.visit_optional_expression(while_.condition.as_deref());
+            builder.visit_optional_expression(while_.continue_expr.as_deref());
+            builder.visit_optional_expression(while_.body.as_deref());
+        });
+        self.emit(Node::Loop { body });
+        self.visit_optional_expression(while_.else_branch.as_deref());
+    }
+
+    fn visit_for_expression(&mut self, for_: &ForExpr) {
+        let body = self.collect(|builder| {
+            builder.visit_for_items(&for_.items);
+            builder.visit_optional_expression(for_.body.as_deref());
+        });
+        self.emit(Node::Loop { body });
+        self.visit_optional_expression(for_.else_branch.as_deref());
+    }
+
+    fn visit_switch_expression(&mut self, switch: &SwitchExpr) {
+        self.visit_optional_expression(switch.target.as_deref());
+        let mut cases = Vec::with_capacity(switch.prongs.len());
+        for prong in &switch.prongs {
+            let body = self.collect(|builder| builder.visit_expression(&prong.body));
+            cases.push(SwitchCase {
+                is_default: prong.cases.iter().any(switch_item_is_default),
+                body,
+            });
+        }
+        self.emit(Node::Switch { cases });
+    }
+
+    fn visit_binary(&mut self, binary: &BinaryOp) {
+        let Some(op) = logical_op(&binary.op) else {
+            self.visit_expression(&binary.lhs);
+            self.visit_expression(&binary.rhs);
+            return;
+        };
+        let mut operands = Vec::new();
+        self.collect_logical_side(&binary.lhs, op, &mut operands);
+        self.collect_logical_side(&binary.rhs, op, &mut operands);
+        self.emit(Node::Logical { op, operands });
+    }
+
+    fn collect_logical_side(
+        &mut self,
+        expression: &Expression,
+        op: LogicalOp,
+        out: &mut Vec<Node>,
+    ) {
+        if let Expression::Grouped(inner) = expression {
+            self.collect_logical_side(inner, op, out);
+            return;
+        }
+        if let Expression::Binary(binary) = expression
+            && let Some(inner_op) = logical_op(&binary.op)
+        {
+            if inner_op == op {
+                self.collect_logical_side(&binary.lhs, op, out);
+                self.collect_logical_side(&binary.rhs, op, out);
+            } else {
+                let mut operands = Vec::new();
+                self.collect_logical_side(&binary.lhs, inner_op, &mut operands);
+                self.collect_logical_side(&binary.rhs, inner_op, &mut operands);
+                out.push(Node::Logical {
+                    op: inner_op,
+                    operands,
+                });
+            }
+            return;
+        }
+        out.push(Node::Group(
+            self.collect(|builder| builder.visit_expression(expression)),
+        ));
+    }
+
+    fn visit_catch(&mut self, catch: &CatchExpr) {
+        self.visit_expression(&catch.lhs);
+        let body = self.collect(|builder| builder.visit_expression(&catch.rhs));
+        self.emit(Node::Catch { body });
+    }
+
+    // ---- transparent child traversal -------------------------------------
+
+    fn visit_asm(&mut self, asm: &AsmExpr) {
+        self.visit_optional_expression(asm.expr.as_deref());
+        for output in &asm.outputs {
+            self.visit_expression(&output.constraint);
+            match &output.target {
+                AsmOutputTarget::Type(ty) => self.visit_expression(ty),
+                AsmOutputTarget::Ident(_) => {}
+            }
+        }
+        for input in &asm.inputs {
+            self.visit_expression(&input.constraint);
+            self.visit_expression(&input.expr);
+        }
+        self.visit_optional_expression(asm.clobbers.as_deref());
+    }
+
+    fn visit_init_entry(&mut self, entry: &InitEntry) {
+        match entry {
+            InitEntry::Field { value, .. } | InitEntry::Expr(value) => self.visit_expression(value),
+        }
+    }
+
+    fn visit_pointer_modifiers(&mut self, modifiers: &[PointerModifier]) {
+        for modifier in modifiers {
+            match modifier {
+                PointerModifier::Align(expressions) => self.visit_expressions(expressions),
+                PointerModifier::AddrSpace(expression) => self.visit_expression(expression),
+                PointerModifier::Const | PointerModifier::Volatile | PointerModifier::AllowZero => {
+                }
+            }
+        }
+    }
+
+    fn visit_for_items(&mut self, items: &[ForItem]) {
+        for item in items {
+            self.visit_expression(&item.expr);
+            if let Some(Some(end)) = &item.range {
+                self.visit_expression(end);
+            }
+        }
+    }
+
+    fn visit_expressions(&mut self, expressions: &[Expression]) {
+        for expression in expressions {
+            self.visit_expression(expression);
+        }
+    }
+
+    fn visit_optional_expression(&mut self, expression: Option<&Expression>) {
+        if let Some(expression) = expression {
+            self.visit_expression(expression);
+        }
+    }
+}
+
+fn logical_op(token: &Token) -> Option<LogicalOp> {
+    match token {
+        Token::Keyword(Keyword::And) => Some(LogicalOp::And),
+        Token::Keyword(Keyword::Or) => Some(LogicalOp::Or),
+        Token::Keyword(Keyword::Orelse) => Some(LogicalOp::Coalesce),
+        _ => None,
+    }
+}
+
+fn callee_name(expression: &Expression) -> Option<String> {
+    match expression {
+        Expression::Ident(ident) => Some(ident.name.clone()),
+        Expression::FieldAccess(field) => Some(field.field.name.clone()),
+        Expression::Grouped(inner) => callee_name(inner),
+        _ => None,
+    }
+}
+
+fn expression_label(expression: &Expression) -> String {
+    match expression {
+        Expression::Ident(ident) => ident.name.clone(),
+        Expression::BasicLit(literal) => literal.text.trim_matches('"').to_string(),
+        _ => "<anonymous>".to_string(),
+    }
+}
+
+fn switch_item_is_default(item: &SwitchItem) -> bool {
+    match item {
+        SwitchItem::Expr(_) | SwitchItem::Range(_, _) => false,
+        SwitchItem::Else(_) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cccc_core::report::FunctionReport;
+
+    fn analyze(source: &str) -> FileReport {
+        analyze_source(Path::new("test.zig"), source)
+    }
+
+    fn find<'a>(functions: &'a [FunctionReport], name: &str) -> Option<&'a FunctionReport> {
+        for function in functions {
+            if function.name == name {
+                return Some(function);
+            }
+            if let Some(found) = find(&function.children, name) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn cognitive_of(source: &str, name: &str) -> u32 {
+        find(&analyze(source).functions, name)
+            .unwrap_or_else(|| panic!("function {name} not found"))
+            .cognitive
+    }
+
+    fn cyclomatic_of(source: &str, name: &str) -> u32 {
+        find(&analyze(source).functions, name)
+            .unwrap_or_else(|| panic!("function {name} not found"))
+            .cyclomatic
+    }
+
+    #[test]
+    fn sonar_sum_of_primes_is_7() {
+        let source = r#"
+pub fn sumOfPrimes(max: u32) u32 {
+    var total: u32 = 0;
+    outer: for (2..max) |i| {
+        for (2..i) |j| {
+            if (i % j == 0) {
+                continue :outer;
+            }
+        }
+        total += i;
+    }
+    return total;
+}
+"#;
+        assert_eq!(cognitive_of(source, "sumOfPrimes"), 7);
+        assert_eq!(cyclomatic_of(source, "sumOfPrimes"), 4);
+    }
+
+    #[test]
+    fn switch_else_is_the_default_arm() {
+        let source = r#"
+fn classify(value: u8) []const u8 {
+    return switch (value) {
+        1 => "one",
+        2 => "two",
+        else => "many",
+    };
+}
+"#;
+        assert_eq!(cognitive_of(source, "classify"), 1);
+        assert_eq!(cyclomatic_of(source, "classify"), 3);
+    }
+
+    #[test]
+    fn else_if_and_else_are_flat() {
+        let source = r#"
+fn choose(a: bool, b: bool) void {
+    if (a) {
+        useA();
+    } else if (b) {
+        useB();
+    } else {
+        useDefault();
+    }
+}
+"#;
+        assert_eq!(cognitive_of(source, "choose"), 3);
+        assert_eq!(cyclomatic_of(source, "choose"), 3);
+    }
+
+    #[test]
+    fn logical_and_coalescing_runs_fold_by_operator() {
+        let source = r#"
+fn choose(a: bool, b: bool, c: bool, fallback: ?bool) bool {
+    return (a and b and c) or (fallback orelse false);
+}
+"#;
+        assert_eq!(cognitive_of(source, "choose"), 3);
+        assert_eq!(cyclomatic_of(source, "choose"), 5);
+    }
+
+    #[test]
+    fn catch_handler_is_nested() {
+        let source = r#"
+fn recover() void {
+    risky() catch |err| {
+        if (isFatal(err)) {
+            return;
+        }
+    };
+}
+"#;
+        assert_eq!(cognitive_of(source, "recover"), 3);
+        assert_eq!(cyclomatic_of(source, "recover"), 3);
+    }
+
+    #[test]
+    fn loop_else_runs_at_the_surrounding_level() {
+        let source = r#"
+fn wait(ready: bool, fallback: bool) void {
+    while (ready) {
+        tick();
+    } else {
+        if (fallback) useFallback();
+    }
+}
+"#;
+        assert_eq!(cognitive_of(source, "wait"), 2);
+        assert_eq!(cyclomatic_of(source, "wait"), 3);
+    }
+
+    #[test]
+    fn recursion_and_labelled_jumps_are_detected() {
+        let source = r#"
+fn walk(n: u32) u32 {
+    if (n == 0) return 0;
+    return walk(n - 1);
+}
+
+fn scan(items: []const u8) void {
+    outer: for (items) |_| {
+        break :outer;
+    }
+}
+"#;
+        assert_eq!(cognitive_of(source, "walk"), 2);
+        assert_eq!(cognitive_of(source, "scan"), 2);
+    }
+
+    #[test]
+    fn functions_in_containers_and_tests_are_units() {
+        let source = r#"
+const Service = struct {
+    fn run(ok: bool) void {
+        if (ok) work();
+    }
+};
+
+test "service" {
+    if (enabled()) work();
+}
+"#;
+        let report = analyze(source);
+        let run = find(&report.functions, "run").expect("run");
+        let test = find(&report.functions, "test service").expect("test service");
+        assert_eq!((run.kind.as_str(), run.cognitive), ("function", 1));
+        assert_eq!((test.kind.as_str(), test.cognitive), ("test", 1));
+    }
+
+    #[test]
+    fn module_level_comptime_is_scored() {
+        let source = r#"
+comptime {
+    if (enabled()) generate();
+}
+"#;
+        let report = analyze(source);
+        assert_eq!(report.cognitive, 1);
+        assert!(report.functions.is_empty());
+    }
+
+    #[test]
+    fn function_line_comes_from_source_position() {
+        let source = "\n\nfn third() void {}\n";
+        let report = analyze(source);
+        assert_eq!(find(&report.functions, "third").expect("third").line, 3);
+    }
+
+    #[test]
+    fn parse_error_is_reported() {
+        let (nodes, errors) = to_ir(Path::new("bad.zig"), "fn broken( {");
+        assert!(nodes.is_empty());
+        assert!(!errors.is_empty());
+    }
+}


### PR DESCRIPTION
Add a Zig front-end that lowers source into the shared complexity IR, following the same pattern as cccc-go: the pure-Rust [zigsyn](https://docs.rs/zigsyn) parser with an exhaustive AST traversal so constructs in nested expression positions remain visible.

Mapping highlights:
- named `fn` declarations -> `"function"` units, and `test` blocks -> `"test"` units
- `if`/`else if`/`else` -> Branch, with `else if` chains scored flat
- `while`/`for` -> Loop; a loop's `else` branch runs at the surrounding level
- `switch` -> Switch; an `else` prong is the non- decision default arm
- `catch` handlers -> Catch, while `try` propagation remains transparent
- `and`/`or` runs fold by operator; `orelse` folds as Coalesce
- labelled `break`/`continue` -> labeled Jump
- direct and field-access calls -> Call for recursion detection

zigsyn parses a whole file at once, so parse failures are surfaced in the report rather than producing partial complexity results. Registered as `--lang zig`, claiming `.zig`, with adapter tests, a CLI fixture and smoke coverage, workspace wiring, lockfile updates, and documentation.