### PR TITLE
Surface parse errors in the summary and warn on stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,50 @@ the tail where refactoring candidates live. It is unaffected by `--min`.
   "summary": {
     "file_count": 1,
     "function_count": 3,
+    "parse_error_count": 0,
+    "parse_error_file_count": 0,
     "cognitive":  { "sum": 10, "max": 7, "median": 2, "p90": 7, "p95": 7 },
     "cyclomatic": { "sum": 10, "max": 4, "median": 3, "p90": 4, "p95": 4 }
   }
 }
+```
+
+### Parse errors
+
+A file that fails to parse cleanly is still measured from whatever the parser
+recovered, and its `parse_errors` (an array of messages, omitted when empty)
+appears on that file's entry. The `summary` aggregates them — `parse_error_count`
+(total errors), `parse_error_file_count` (affected files), and
+`parse_error_files` (the affected paths, omitted when empty) — so a partial
+parse can't go unnoticed without inspecting every file entry, even in `--top-*`
+mode where per-file entries aren't emitted at all:
+
+```json
+{
+  "files": [
+    {
+      "path": "src/broken.py",
+      "parse_errors": ["syntax error at line 6"],
+      ...
+    }
+  ],
+  "summary": {
+    "parse_error_count": 1,
+    "parse_error_file_count": 1,
+    "parse_error_files": ["src/broken.py"],
+    ...
+  }
+}
+```
+
+In `--table` mode the aggregate count is printed in the summary block, and a
+warning listing each affected file (with its error count) goes to stderr so it
+isn't lost in a long table:
+
+```console
+$ cccc --table src/ >/dev/null
+cccc: warning: 1 parse error(s) in 1 file(s); results for those files may be incomplete:
+cccc:   src/broken.py (1)
 ```
 
 > Note: the top level is an object (`{ files, summary }`), so to post-process

--- a/crates/cccc-cli/src/lib.rs
+++ b/crates/cccc-cli/src/lib.rs
@@ -140,9 +140,9 @@ pub fn run() -> i32 {
     } else {
         for ext in &global_ext {
             if !dispatch.contains_key(ext) {
-                eprintln!(
+                output::warn(&format!(
                     "cccc: warning: no active language analyzes .{ext} files; they will be skipped"
-                );
+                ));
             }
         }
         global_ext
@@ -207,6 +207,19 @@ pub fn run() -> i32 {
     // Compute the summary over the full population, before `--min`/`--top` change
     // what is displayed, so the distribution always reflects all code.
     let summary = report::compute_summary(&reports);
+
+    // Parse errors mean the scores may be computed from a partial parse. JSON
+    // consumers see this in `summary`; for the human-readable views, warn on
+    // stderr — with the affected paths — so it isn't lost in a long table.
+    if table && summary.parse_error_count > 0 {
+        output::warn(&format!(
+            "cccc: warning: {} parse error(s) in {} file(s); results for those files may be incomplete:",
+            summary.parse_error_count, summary.parse_error_file_count
+        ));
+        for r in reports.iter().filter(|r| !r.parse_errors.is_empty()) {
+            output::warn(&format!("cccc:   {} ({})", r.path, r.parse_errors.len()));
+        }
+    }
 
     // `--top-*` is a distinct, flat ranking view that replaces the per-file
     // output. The two top flags are mutually exclusive (enforced by clap).

--- a/crates/cccc-cli/src/output.rs
+++ b/crates/cccc-cli/src/output.rs
@@ -2,10 +2,32 @@
 //! views. The report *data* and aggregation live in `cccc_core::report`; this
 //! module only formats them.
 
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 
 use cccc_core::report::{FunctionReport, MetricSummary, Report, Summary, TopReport};
 use serde::Serialize;
+
+/// True when ANSI color should be used on `stream`: it is a real terminal and
+/// the user hasn't opted out via `NO_COLOR` (<https://no-color.org>). Piped or
+/// redirected output stays plain so logs and CI captures aren't polluted with
+/// escape codes.
+fn use_color(stream: &impl IsTerminal) -> bool {
+    std::env::var_os("NO_COLOR").is_none() && stream.is_terminal()
+}
+
+/// Wrap `msg` in ANSI yellow when `enabled`.
+fn yellow(msg: &str, enabled: bool) -> std::borrow::Cow<'_, str> {
+    if enabled {
+        format!("\x1b[33m{msg}\x1b[0m").into()
+    } else {
+        msg.into()
+    }
+}
+
+/// Print a warning line to stderr, in yellow when stderr is a terminal.
+pub fn warn(msg: &str) {
+    eprintln!("{}", yellow(msg, use_color(&std::io::stderr())));
+}
 
 /// Print any serializable value as pretty JSON to stdout.
 ///
@@ -32,6 +54,7 @@ pub fn print_json<T: Serialize>(value: &T) {
 /// `BufWriter` never fails for stdout in practice, so write errors (e.g. a
 /// closed pipe) are reported once at the end rather than per line.
 pub fn print_table(report: &Report) {
+    let color = use_color(&std::io::stdout());
     with_stdout(|out| {
         for file in &report.files {
             writeln!(out, "{}", file.path)?;
@@ -49,16 +72,17 @@ pub fn print_table(report: &Report) {
                 file.cognitive, file.cyclomatic
             )?;
             for e in &file.parse_errors {
-                writeln!(out, "  parse warning: {e}")?;
+                writeln!(out, "{}", yellow(&format!("  parse warning: {e}"), color))?;
             }
             writeln!(out)?;
         }
-        write_summary(out, &report.summary)
+        write_summary(out, &report.summary, color)
     });
 }
 
 /// Print a flat ranking as a human-readable table, followed by the summary.
 pub fn print_top_table(report: &TopReport) {
+    let color = use_color(&std::io::stdout());
     with_stdout(|out| {
         writeln!(out, "top {} by {}", report.top.len(), report.metric)?;
         writeln!(out, "  {:>9}  {:>10}  Function", "Cognitive", "Cyclomatic")?;
@@ -73,7 +97,7 @@ pub fn print_top_table(report: &TopReport) {
             )?;
         }
         writeln!(out, "  {}", "-".repeat(48))?;
-        write_summary(out, &report.summary)
+        write_summary(out, &report.summary, color)
     });
 }
 
@@ -90,7 +114,7 @@ where
     }
 }
 
-fn write_summary(out: &mut dyn Write, s: &Summary) -> std::io::Result<()> {
+fn write_summary(out: &mut dyn Write, s: &Summary, color: bool) -> std::io::Result<()> {
     writeln!(
         out,
         "summary ({} files, {} functions)",
@@ -102,7 +126,15 @@ fn write_summary(out: &mut dyn Write, s: &Summary) -> std::io::Result<()> {
         "", "sum", "max", "median", "p90", "p95"
     )?;
     write_metric_row(out, "cognitive", &s.cognitive)?;
-    write_metric_row(out, "cyclomatic", &s.cyclomatic)
+    write_metric_row(out, "cyclomatic", &s.cyclomatic)?;
+    if s.parse_error_count > 0 {
+        let line = format!(
+            "  parse errors: {} in {} file(s)",
+            s.parse_error_count, s.parse_error_file_count
+        );
+        writeln!(out, "{}", yellow(&line, color))?;
+    }
+    Ok(())
 }
 
 fn write_metric_row(out: &mut dyn Write, label: &str, m: &MetricSummary) -> std::io::Result<()> {

--- a/crates/cccc-cli/tests/cli.rs
+++ b/crates/cccc-cli/tests/cli.rs
@@ -235,6 +235,73 @@ fn table_output_renders() {
         .stdout(predicates::str::contains("summary"));
 }
 
+// ----- parse-error reporting --------------------------------------------------
+
+/// Create `broken.py` (one valid function, one syntax error) in a fresh temp
+/// dir. Python goes through tree-sitter, which recovers from the error, so the
+/// valid function is still measured and the error is reported alongside.
+fn write_broken_py(dir_name: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+    let dir = std::env::temp_dir().join(dir_name);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("broken.py");
+    std::fs::write(
+        &path,
+        "def ok(a):\n    if a:\n        return 1\n    return 0\n\ndef broken(:\n    pass\n",
+    )
+    .unwrap();
+    (dir, path)
+}
+
+#[test]
+fn json_summary_counts_parse_errors() {
+    let (dir, path) = write_broken_py("cccc_parse_error_json_test");
+    let v = json(&[path.to_str().unwrap()]);
+    let s = &v["summary"];
+    assert!(s["parse_error_count"].as_u64().unwrap() >= 1);
+    assert_eq!(s["parse_error_file_count"], 1);
+    let error_files = s["parse_error_files"].as_array().unwrap();
+    assert_eq!(error_files.len(), 1);
+    assert!(error_files[0].as_str().unwrap().ends_with("broken.py"));
+    let file = &v["files"][0];
+    assert!(!file["parse_errors"].as_array().unwrap().is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_summary_reports_zero_parse_errors_for_clean_input() {
+    let v = json(&["tests/fixtures/sample.ts"]);
+    assert_eq!(v["summary"]["parse_error_count"], 0);
+    assert_eq!(v["summary"]["parse_error_file_count"], 0);
+    assert!(v["summary"].get("parse_error_files").is_none());
+}
+
+#[test]
+fn table_mode_warns_about_parse_errors_on_stderr() {
+    let (dir, path) = write_broken_py("cccc_parse_error_table_test");
+    Command::cargo_bin("cccc")
+        .unwrap()
+        .args(["--table", path.to_str().unwrap()])
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("cccc: warning:"))
+        .stderr(predicates::str::contains("parse error"))
+        .stderr(predicates::str::contains("broken.py"))
+        .stdout(predicates::str::contains("parse errors:"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_mode_reports_parse_errors_in_output_not_stderr() {
+    let (dir, path) = write_broken_py("cccc_parse_error_json_stderr_test");
+    Command::cargo_bin("cccc")
+        .unwrap()
+        .arg(path.to_str().unwrap())
+        .assert()
+        .success()
+        .stderr(predicates::str::is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 // ----- multi-language dispatch & --lang -------------------------------------
 
 #[test]

--- a/crates/cccc-core/src/report.rs
+++ b/crates/cccc-core/src/report.rs
@@ -52,6 +52,17 @@ pub struct MetricSummary {
 pub struct Summary {
     pub file_count: usize,
     pub function_count: usize,
+    /// Total parse errors across all files. Parsers are fault-tolerant where
+    /// possible, so a non-zero count means some code was measured from a
+    /// partial parse (or, for non-recovering parsers, skipped entirely).
+    pub parse_error_count: usize,
+    /// Number of files that had at least one parse error.
+    pub parse_error_file_count: usize,
+    /// Paths of the files that had parse errors, in report order. Lets a
+    /// consumer locate the affected files without scanning every entry in
+    /// `files` (which the `--top-*` output doesn't even include).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub parse_error_files: Vec<String>,
     pub cognitive: MetricSummary,
     pub cyclomatic: MetricSummary,
 }
@@ -181,15 +192,24 @@ fn metric_summary(mut values: Vec<u32>) -> MetricSummary {
 pub fn compute_summary(reports: &[FileReport]) -> Summary {
     let mut cog = Vec::new();
     let mut cyc = Vec::new();
+    let mut parse_error_count = 0;
+    let mut parse_error_files = Vec::new();
     for r in reports {
         for_each_function(&r.functions, &mut |f| {
             cog.push(f.cognitive);
             cyc.push(f.cyclomatic);
         });
+        if !r.parse_errors.is_empty() {
+            parse_error_count += r.parse_errors.len();
+            parse_error_files.push(r.path.clone());
+        }
     }
     Summary {
         file_count: reports.len(),
         function_count: cog.len(),
+        parse_error_count,
+        parse_error_file_count: parse_error_files.len(),
+        parse_error_files,
         cognitive: metric_summary(cog),
         cyclomatic: metric_summary(cyc),
     }
@@ -211,5 +231,39 @@ mod tests {
     #[test]
     fn percentile_empty_is_zero() {
         assert_eq!(percentile(&[], 50.0), 0);
+    }
+
+    #[test]
+    fn summary_aggregates_parse_errors() {
+        let file = |path: &str, errors: Vec<String>| FileReport {
+            path: path.to_string(),
+            cognitive: 0,
+            cyclomatic: 0,
+            functions: Vec::new(),
+            parse_errors: errors,
+        };
+        let reports = vec![
+            file("clean", Vec::new()),
+            file("one", vec!["syntax error at line 1".to_string()]),
+            file(
+                "two",
+                vec![
+                    "syntax error at line 3".to_string(),
+                    "syntax error at line 9".to_string(),
+                ],
+            ),
+        ];
+        let s = compute_summary(&reports);
+        assert_eq!(s.parse_error_count, 3);
+        assert_eq!(s.parse_error_file_count, 2);
+        assert_eq!(s.parse_error_files, vec!["one", "two"]);
+    }
+
+    #[test]
+    fn summary_without_parse_errors_is_zero() {
+        let s = compute_summary(&[]);
+        assert_eq!(s.parse_error_count, 0);
+        assert_eq!(s.parse_error_file_count, 0);
+        assert!(s.parse_error_files.is_empty());
     }
 }

--- a/crates/cccc-es/src/lib.rs
+++ b/crates/cccc-es/src/lib.rs
@@ -574,4 +574,13 @@ mod tests {
         assert_eq!(outer.children.len(), 1);
         assert_eq!(outer.children[0].name, "inner");
     }
+
+    #[test]
+    fn parse_error_is_reported() {
+        // A hard syntax error makes oxc bail on the whole file (empty program),
+        // so nothing is measured — but the diagnostic must still be surfaced.
+        let (nodes, errors) = to_ir(Path::new("bad.ts"), "function ok() {}\nfunction bad( {\n");
+        assert!(nodes.is_empty());
+        assert!(!errors.is_empty());
+    }
 }

--- a/crates/cccc-kt/src/lib.rs
+++ b/crates/cccc-kt/src/lib.rs
@@ -830,4 +830,12 @@ mod tests {
         assert_eq!(f.kind, "method");
         assert_eq!(f.cognitive, 1);
     }
+
+    #[test]
+    fn parse_error_is_reported() {
+        // tree-sitter is fault-tolerant: it still yields a (partial) tree but
+        // surfaces the error location for the broken input.
+        let errors = parse_errors("fun ok(a: Int): Int { return a }\nfun bad( {\n");
+        assert!(!errors.is_empty());
+    }
 }

--- a/docs/ADDING_A_LANGUAGE.md
+++ b/docs/ADDING_A_LANGUAGE.md
@@ -91,6 +91,15 @@ pub fn analyze_source(path: &Path, source: &str) -> FileReport {
 Optionally also expose `to_ir(path, source) -> (Vec<Node>, Vec<String>)` (the IR
 plus parser-error strings) for embedders who want the raw IR — `cccc-es` does.
 
+Populate the parse-error strings whenever the parse was not clean — one entry
+per error, e.g. `"syntax error at line 42"`. If your parser is fault-tolerant
+(tree-sitter grammars, oxc, Prism, …), still lower whatever parsed and report
+the error locations alongside; the engine attaches them to the file's
+`parse_errors` and the CLI aggregates them into the summary
+(`parse_error_count` / `parse_error_file_count` / `parse_error_files`) and
+warns on stderr — listing the affected files — in `--table` mode, so partial
+parses are surfaced without any adapter-side work.
+
 ## Step 2 — lower the AST to IR
 
 This is the only real work. You walk your parser's AST and emit


### PR DESCRIPTION
A run over a large tree can hit files that only partially parse (or not at all), and until now the only trace was the per-file parse_errors entries — easy to miss without inspecting every file in the output (moznion/cccc#44).

Aggregate them at the point every FileReport already flows through (compute_summary), so every language adapter — current and future — is covered without any adapter-side change:

- JSON: summary gains parse_error_count, parse_error_file_count, and parse_error_files (the affected paths; omitted when empty). Since Summary is shared, this also appears in --top-* output, which emits no per-file entries at all.
- --table: the summary block gains a "parse errors: N in M file(s)" line, and a warning listing each affected file (with its error count) goes to stderr so it isn't lost in a long table.

Warnings are rendered in yellow when the target stream is a terminal, honoring NO_COLOR and staying plain when piped or redirected.