### PR TITLE
Add null guard semantics to the core IR

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,9 @@ harness, per-run numbers, function-count sanity checks, and caveats.
 
 **Cyclomatic (McCabe):** base 1 per function; +1 for each `if`/`else if`,
 ternary, `for`/`for-in`/`for-of`/`while`/`do-while`, `case` (excluding
-`default`), `catch`, and each `&&`/`||`/`??`.
+`default`), `catch`, each `&&`/`||`/`??`, and each explicit null guard such as
+an optional-chain segment. Null guards do not add cognitive complexity or
+nesting.
 
 **Cognitive (SonarSource):**
 - +1 plus a nesting bonus for `if`, ternary, `switch`, loops, `catch`.
@@ -389,6 +391,12 @@ arm is the non-decision case), `catch` clauses, multi-level `break N`/
 `continue N` and `goto`, the ternary `?:`, and `&&`/`and`/`||`/`or`/`??` map to
 the corresponding nodes. `&&` and `and` (likewise `||` and `or`) are the same
 normalized operator; `??` folds as a coalescing run.
+Each null-safe property or method access (`?->`) adds one cyclomatic path.
+
+For **Ruby** (`--lang ruby`): methods, blocks, and lambdas are function-like
+units; branches, loops, `case`/`when` and `case`/`in`, rescue clauses, ternary
+expressions, and logical operators map to the corresponding nodes. Each safe
+navigation operator (`&.`) adds one cyclomatic path.
 
 For **Kotlin** (`--lang kotlin`): `fun` declarations / methods / local
 functions / `fun` anonymous functions / lambdas / property `get`/`set`
@@ -398,7 +406,7 @@ a subject (its `else` entry is the non-decision `default` arm), `for`/`while`/
 `do`-`while`, `catch` clauses, labelled `break@`/`continue@`, and `&&`/`||` map
 to the corresponding nodes. The elvis operator `?:` folds as a coalescing run
 (like PHP's `??`). Kotlin has no C-style ternary — `if` is already an
-expression.
+expression. Each safe-navigation operator (`?.`) adds one cyclomatic path.
 
 For **Python** (`--lang python`): `def` (incl. `async def` and decorated
 definitions) / methods / `lambda` are the function-like units;
@@ -458,7 +466,8 @@ arm), `for`-`in` (its `where` clause adds nothing by itself), `while`/
 `a ? b : c`, and `&&`/`||` map to the corresponding nodes. Nil-coalescing `??`
 folds as a coalescing run (like PHP's `??`). `#if` compilation directives are
 transparent — every branch's code scores where it stands; `try`/`try?`/`await`
-add nothing.
+add nothing. Each optional-chaining guard on a member access, subscript, or call
+adds one cyclomatic path.
 
 For **Java** (`--lang java`): methods (incl. ones in anonymous classes and
 interface `default` methods) / constructors / record compact constructors /

--- a/crates/cccc-core/src/engine.rs
+++ b/crates/cccc-core/src/engine.rs
@@ -13,8 +13,8 @@
 //! ## Cyclomatic Complexity (McCabe)
 //!
 //! Base 1 per function; +1 for each branch (`if`/`else if`), ternary, loop,
-//! non-default `case`, `catch`, and each logical operator (one per extra operand
-//! in a [`Node::Logical`]).
+//! non-default `case`, `catch`, explicit null guard, and each logical
+//! operator (one per extra operand in a [`Node::Logical`]).
 //!
 //! ## Cognitive Complexity (SonarSource)
 //!
@@ -156,6 +156,10 @@ impl Engine {
                 }
             }
             Node::Logical { operands, .. } => self.visit_logical(operands),
+            Node::NullGuard { body } => {
+                self.add_cyclomatic();
+                self.walk(body);
+            }
             Node::Call { callee } => self.visit_call(callee.as_deref()),
             Node::Group(children) => self.walk(children),
         }
@@ -410,6 +414,16 @@ mod tests {
         assert_eq!(cog(&r, "f"), 3);
         // cyc: base1 + if1 + (&& has 3 operands => +2) + (|| has 2 => +1) = 5
         assert_eq!(cyc(&r, "f"), 5);
+    }
+
+    #[test]
+    fn null_guard_adds_only_a_cyclomatic_path() {
+        let null_guard = Node::NullGuard {
+            body: vec![Node::Call { callee: None }],
+        };
+        let r = analyze("t", &[func("f", "function", vec![null_guard])], vec![]);
+        assert_eq!(cog(&r, "f"), 0);
+        assert_eq!(cyc(&r, "f"), 2); // base 1 + optional path 1
     }
 
     #[test]

--- a/crates/cccc-core/src/ir.rs
+++ b/crates/cccc-core/src/ir.rs
@@ -84,6 +84,15 @@ pub enum Node {
     /// adapter folds `a && b && c` into a single node with three operands.
     Logical { op: LogicalOp, operands: Vec<Node> },
 
+    /// An implicit null-dependent control-flow split.
+    ///
+    /// The guarded continuation or collection contribution proceeds only when
+    /// the source-language value is present (non-null, non-nil, or non-nullish).
+    /// Each explicit source-level guard adds one cyclomatic path without adding
+    /// cognitive complexity or nesting. Null coalescing remains a
+    /// [`Node::Logical`] with [`LogicalOp::Coalesce`].
+    NullGuard { body: Vec<Node> },
+
     /// A function call. If `callee` names the nearest enclosing function, the
     /// engine counts it as recursion (one cognitive point).
     Call { callee: Option<String> },

--- a/crates/cccc-es/src/lib.rs
+++ b/crates/cccc-es/src/lib.rs
@@ -10,8 +10,9 @@
 //!
 //! This crate contains **no scoring logic** — it only recognizes the constructs
 //! the engine cares about (functions, branches, loops, switches, catches,
-//! labelled jumps, logical-operator sequences, calls) and emits the matching IR
-//! nodes. All complexity rules live in [`cccc_core::engine`].
+//! labelled jumps, logical-operator sequences, optional-chain guards, calls) and
+//! emits the matching IR nodes. All complexity rules live in
+//! [`cccc_core::engine`].
 //!
 //! ## Why a `Visit`-driven builder
 //!
@@ -348,11 +349,46 @@ impl<'a> Visit<'a> for Builder {
         });
     }
 
+    fn visit_computed_member_expression(&mut self, it: &ComputedMemberExpression<'a>) {
+        if it.optional {
+            let body = self.collect(|s| walk::walk_computed_member_expression(s, it));
+            self.emit(Node::NullGuard { body });
+        } else {
+            walk::walk_computed_member_expression(self, it);
+        }
+    }
+
+    fn visit_static_member_expression(&mut self, it: &StaticMemberExpression<'a>) {
+        if it.optional {
+            let body = self.collect(|s| walk::walk_static_member_expression(s, it));
+            self.emit(Node::NullGuard { body });
+        } else {
+            walk::walk_static_member_expression(self, it);
+        }
+    }
+
+    fn visit_private_field_expression(&mut self, it: &PrivateFieldExpression<'a>) {
+        if it.optional {
+            let body = self.collect(|s| walk::walk_private_field_expression(s, it));
+            self.emit(Node::NullGuard { body });
+        } else {
+            walk::walk_private_field_expression(self, it);
+        }
+    }
+
     fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
-        self.emit(Node::Call {
-            callee: callee_name(&it.callee),
-        });
-        walk::walk_call_expression(self, it);
+        let lower = |s: &mut Self| {
+            s.emit(Node::Call {
+                callee: callee_name(&it.callee),
+            });
+            walk::walk_call_expression(s, it);
+        };
+        if it.optional {
+            let body = self.collect(lower);
+            self.emit(Node::NullGuard { body });
+        } else {
+            lower(self);
+        }
     }
 }
 
@@ -420,6 +456,12 @@ mod tests {
         find(&analyze(src).functions, name)
             .unwrap_or_else(|| panic!("function {name} not found"))
             .cognitive
+    }
+
+    fn cyclomatic_of(src: &str, name: &str) -> u32 {
+        find(&analyze(src).functions, name)
+            .unwrap_or_else(|| panic!("function {name} not found"))
+            .cyclomatic
     }
 
     #[test]
@@ -493,6 +535,20 @@ mod tests {
             }
         "#;
         assert_eq!(cognitive_of(src, "f"), 3);
+    }
+
+    #[test]
+    fn optional_chain_guards_add_only_cyclomatic_paths() {
+        let src = r#"
+            function f(value, key, callback) {
+                value?.member;
+                value?.[key];
+                callback?.();
+                value?.method?.();
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 0);
+        assert_eq!(cyclomatic_of(src, "f"), 6); // base + five explicit `?.`
     }
 
     #[test]

--- a/crates/cccc-kt/src/lib.rs
+++ b/crates/cccc-kt/src/lib.rs
@@ -40,6 +40,7 @@
 //!   `break` / `continue` score flat. `return` / `throw` are transparent.
 //! - `&&` / `||` runs → folded [`Node::Logical`]; the elvis operator `?:` folds
 //!   as a `Coalesce` run (mirroring how `cccc-php` treats `??`).
+//! - safe navigation (`?.`) → one [`Node::NullGuard`] per explicit guard.
 //! - calls (`f(..)`, `obj.m(..)`) → [`Node::Call`] for recursion detection.
 
 use std::path::Path;
@@ -231,6 +232,11 @@ impl<'a> Builder<'a> {
             "disjunction_expression" => self.visit_logical(node, LogicalOp::Or),
             "elvis_expression" => self.visit_logical(node, LogicalOp::Coalesce),
 
+            "navigation_suffix" if has_direct_child(node, "?.") => {
+                let body = self.collect(|b| b.visit_named_children(node));
+                self.emit(Node::NullGuard { body });
+            }
+
             "call_expression" => self.visit_call(node),
 
             // Everything else is transparent: recurse into every named child so
@@ -412,6 +418,11 @@ fn named_children(node: TsNode) -> Vec<TsNode> {
         .collect()
 }
 
+fn has_direct_child(node: TsNode, kind: &str) -> bool {
+    let mut cursor = node.walk();
+    node.children(&mut cursor).any(|child| child.kind() == kind)
+}
+
 /// The normalized logical operator a node represents, if any.
 fn logical_op_of(node: TsNode) -> Option<LogicalOp> {
     match node.kind() {
@@ -558,6 +569,18 @@ mod tests {
         assert_eq!(cognitive_of(src, "f"), 1);
         // base 1 + (elvis has 3 operands => +2) = 3
         assert_eq!(cyclomatic_of(src, "f"), 3);
+    }
+
+    #[test]
+    fn safe_navigation_guards_add_only_cyclomatic_paths() {
+        let src = r#"
+            fun f(value: Value?) {
+                value?.property
+                value?.child?.run()
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 0);
+        assert_eq!(cyclomatic_of(src, "f"), 4); // base + three explicit `?.`
     }
 
     #[test]

--- a/crates/cccc-php/src/lib.rs
+++ b/crates/cccc-php/src/lib.rs
@@ -10,8 +10,8 @@
 //! This crate contains **no scoring logic** — it only recognizes the constructs
 //! the engine cares about (functions/methods/closures/arrows/property-hooks,
 //! `if`/`elseif`/`else`, `switch`/`match`, loops, `try`/`catch`, multi-level
-//! `break`/`continue`/`goto`, `&&`/`||`/`and`/`or`/`??` sequences, calls) and
-//! emits the matching IR nodes. All complexity rules live in
+//! `break`/`continue`/`goto`, `&&`/`||`/`and`/`or`/`??` sequences, null-safe
+//! guards, calls) and emits the matching IR nodes. All complexity rules live in
 //! [`cccc_core::engine`].
 //!
 //! ## Lowering strategy
@@ -44,6 +44,8 @@
 //!   [`Node::Jump`]; plain `break` / `continue` score flat.
 //! - `&&` / `and` / `||` / `or` / `??` runs → folded [`Node::Logical`] (one node
 //!   per like-operator run).
+//! - null-safe property/method access (`?->`) → one [`Node::NullGuard`] per
+//!   explicit guard.
 //! - calls (`f(..)`, `$o->m(..)`, `C::m(..)`) → [`Node::Call`] for recursion
 //!   detection.
 
@@ -456,9 +458,23 @@ impl Builder {
                 self.collect_logical_side(right, op, &mut operands);
                 self.emit(Node::Logical { op, operands });
             }
+            ExprKind::NullsafePropertyAccess(_) => {
+                let body = self.collect(|b| {
+                    let _ = walk_owned_expr(b, expr);
+                });
+                self.emit(Node::NullGuard { body });
+            }
+            ExprKind::NullsafeMethodCall(_) => {
+                let body = self.collect(|b| {
+                    b.emit(Node::Call {
+                        callee: callee_name(&expr.kind),
+                    });
+                    let _ = walk_owned_expr(b, expr);
+                });
+                self.emit(Node::NullGuard { body });
+            }
             ExprKind::FunctionCall(_)
             | ExprKind::MethodCall(_)
-            | ExprKind::NullsafeMethodCall(_)
             | ExprKind::StaticMethodCall(_)
             | ExprKind::StaticDynMethodCall(_) => {
                 self.emit(Node::Call {
@@ -759,6 +775,19 @@ mod tests {
         "#;
         // a single folded `??` run = +1
         assert_eq!(cognitive_of(src, "f"), 1);
+    }
+
+    #[test]
+    fn nullsafe_guards_add_only_cyclomatic_paths() {
+        let src = r#"<?php
+            function f($value) {
+                $value?->property;
+                $value?->method();
+                $value?->child?->run();
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 0);
+        assert_eq!(cyclomatic_of(src, "f"), 5); // base + four explicit `?->`
     }
 
     #[test]

--- a/crates/cccc-rb/src/lib.rs
+++ b/crates/cccc-rb/src/lib.rs
@@ -11,8 +11,8 @@
 //! This crate contains **no scoring logic** — it only recognizes the constructs
 //! the engine cares about (`def`/blocks/lambdas, `if`/`elsif`/`else`/`unless`,
 //! ternary, `while`/`until`/`for`, `case`/`when` and `case`/`in`, `rescue`,
-//! `&&`/`and`/`||`/`or`, calls) and emits the matching IR nodes. All complexity
-//! rules live in [`cccc_core::engine`].
+//! `&&`/`and`/`||`/`or`, safe-navigation guards, calls) and emits the matching
+//! IR nodes. All complexity rules live in [`cccc_core::engine`].
 //!
 //! ## Lowering strategy
 //!
@@ -47,6 +47,7 @@
 //!   `or`/`||`). Ruby has no `??`.
 //! - calls → [`Node::Call`] for recursion detection (`m()`, `obj.m()`,
 //!   `self.m()` all yield `Some("m")`).
+//! - safe navigation (`&.`) → one [`Node::NullGuard`] per explicit guard.
 //!
 //! Ruby has no labelled `break`/`next`, so those never produce a cognitive point
 //! and are left to the default walk. Method-based iteration (`loop { }`,
@@ -192,6 +193,40 @@ impl Builder {
         } else {
             // Defensive: any other tail shape scores as a flat `else`.
             Some(Box::new(Node::Group(self.collect(|b| b.visit(&node)))))
+        }
+    }
+
+    // ---- calls ------------------------------------------------------------
+
+    /// Manually walk the children so we can turn a `{ }` / `do…end` block into
+    /// its own `Function` unit (and not double-visit it via the default walk).
+    fn visit_call_children<'pr>(&mut self, node: &CallNode<'pr>) {
+        if let Some(recv) = node.receiver() {
+            self.visit(&recv);
+        }
+        if let Some(args) = node.arguments() {
+            for argument in &args.arguments() {
+                self.visit(&argument);
+            }
+        }
+        if let Some(block) = node.block() {
+            if let Some(block) = block.as_block_node() {
+                let line = self.line(block.location().start_offset());
+                let body = block.body();
+                // A block is anonymous (like an ES/PHP callback): name it
+                // `<block>`, not after the method it is passed to. Borrowing the
+                // method name would make a DSL block that contains sibling calls
+                // to the same method (nested `describe`/`context`, Rails
+                // `namespace`, …) look self-recursive and inflate its score.
+                self.emit_function("<block>".to_string(), "block", line, |b| {
+                    if let Some(body) = &body {
+                        b.visit(body);
+                    }
+                });
+            } else {
+                // A `&blk` block argument: just an expression to recurse into.
+                self.visit(&block);
+            }
         }
     }
 }
@@ -409,37 +444,16 @@ impl<'pr> Visit<'pr> for Builder {
 
     fn visit_call_node(&mut self, node: &CallNode<'pr>) {
         let name = constant_name(node.name().as_slice(), "<call>");
-        // Safe-navigation (`a&.b`) is still a call for recursion purposes.
-        self.emit(Node::Call { callee: Some(name) });
-
-        // Manually walk the children so we can turn a `{ }` / `do…end` block into
-        // its own `Function` unit (and not double-visit it via the default walk).
-        if let Some(recv) = node.receiver() {
-            self.visit(&recv);
-        }
-        if let Some(args) = node.arguments() {
-            for a in &args.arguments() {
-                self.visit(&a);
-            }
-        }
-        if let Some(block) = node.block() {
-            if let Some(block) = block.as_block_node() {
-                let line = self.line(block.location().start_offset());
-                let body = block.body();
-                // A block is anonymous (like an ES/PHP callback): name it
-                // `<block>`, not after the method it is passed to. Borrowing the
-                // method name would make a DSL block that contains sibling calls
-                // to the same method (nested `describe`/`context`, Rails
-                // `namespace`, …) look self-recursive and inflate its score.
-                self.emit_function("<block>".to_string(), "block", line, |b| {
-                    if let Some(body) = &body {
-                        b.visit(body);
-                    }
-                });
-            } else {
-                // A `&blk` block argument: just an expression to recurse into.
-                self.visit(&block);
-            }
+        let lower = |b: &mut Self| {
+            // Safe-navigation (`a&.b`) is still a call for recursion purposes.
+            b.emit(Node::Call { callee: Some(name) });
+            b.visit_call_children(node);
+        };
+        if node.is_safe_navigation() {
+            let body = self.collect(lower);
+            self.emit(Node::NullGuard { body });
+        } else {
+            lower(self);
         }
     }
 }
@@ -733,6 +747,18 @@ mod tests {
             end
         "#;
         assert_eq!(cognitive_of(src, "f"), 1);
+    }
+
+    #[test]
+    fn safe_navigation_guards_add_only_cyclomatic_paths() {
+        let src = r#"
+            def f(value)
+              value&.property
+              value&.child&.run
+            end
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 0);
+        assert_eq!(cyclomatic_of(src, "f"), 4); // base + three explicit `&.`
     }
 
     #[test]

--- a/crates/cccc-swift/src/lib.rs
+++ b/crates/cccc-swift/src/lib.rs
@@ -45,6 +45,8 @@
 //! - ternary `a ? b : c` → [`Node::Conditional`].
 //! - `&&` / `||` runs → folded [`Node::Logical`]; nil-coalescing `??` folds as a
 //!   `Coalesce` run (mirroring how `cccc-php` treats `??`).
+//! - optional chaining for member access, subscripts, and calls → one
+//!   [`Node::NullGuard`] per explicit `?` guard.
 //! - calls (`f(..)`, `obj.m(..)`) → [`Node::Call`] for recursion detection.
 //! - `#if` compilation directives are transparent: every branch's code parses as
 //!   ordinary statements and is scored where it stands.
@@ -224,6 +226,18 @@ impl<'a> Builder<'a> {
             "conjunction_expression" => self.visit_logical(node, LogicalOp::And),
             "disjunction_expression" => self.visit_logical(node, LogicalOp::Or),
             "nil_coalescing_expression" => self.visit_logical(node, LogicalOp::Coalesce),
+
+            "navigation_expression" if has_direct_child(node, "?") => {
+                let body = self.collect(|b| b.visit_named_children(node));
+                self.emit(Node::NullGuard { body });
+            }
+
+            // Optional subscripts (`values?[0]`) and optional function calls
+            // (`callback?()`) are call expressions with a direct `?` child.
+            "call_expression" if has_direct_child(node, "?") => {
+                let body = self.collect(|b| b.visit_call(node));
+                self.emit(Node::NullGuard { body });
+            }
 
             "call_expression" => self.visit_call(node),
 
@@ -481,6 +495,11 @@ fn named_children(node: TsNode) -> Vec<TsNode> {
         .collect()
 }
 
+fn has_direct_child(node: TsNode, kind: &str) -> bool {
+    let mut cursor = node.walk();
+    node.children(&mut cursor).any(|child| child.kind() == kind)
+}
+
 /// The normalized logical operator a node represents, if any.
 fn logical_op_of(node: TsNode) -> Option<LogicalOp> {
     match node.kind() {
@@ -705,6 +724,24 @@ mod tests {
         assert_eq!(cognitive_of(src, "f"), 1);
         // base 1 + (?? has 3 operands => +2) = 3
         assert_eq!(cyclomatic_of(src, "f"), 3);
+    }
+
+    #[test]
+    fn optional_chain_guards_add_only_cyclomatic_paths() {
+        let src = r#"
+            func f(
+                value: Value?,
+                values: [Int]?,
+                callback: (() -> Void)?
+            ) {
+                _ = value?.property
+                _ = value?.child?.run()
+                _ = values?[0]
+                callback?()
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 0);
+        assert_eq!(cyclomatic_of(src, "f"), 6); // base + five explicit `?` guards
     }
 
     #[test]

--- a/docs/ADDING_A_LANGUAGE.md
+++ b/docs/ADDING_A_LANGUAGE.md
@@ -120,10 +120,11 @@ and which scoring it triggers. The mapping for a typical language:
 | `catch` / `except` | `Node::Catch { body }` |
 | labelled `break` / `continue` | `Node::Jump { labeled: true }` (unlabelled → `false`, or just omit) |
 | `&&` / `||` / `??` chains | `Node::Logical { op, operands }` — **fold like operators** (see below) |
+| null-guarded execution / null-aware access | `Node::NullGuard { body }` |
 | function call | `Node::Call { callee: Some(name) }` (for recursion detection) |
 | anything else with children | `Node::Group(children)` |
 
-### Two subtleties to get right
+### Three subtleties to get right
 
 **1. Logical-operator folding (the only lowering logic the adapter owns).**
 A run of *like* operators is **one** `Logical` node: `a && b && c` →
@@ -134,7 +135,13 @@ The engine counts one cognitive point per `Logical` node and one cyclomatic
 point per *extra* operand, so the folding is what makes the SonarSource
 like-operator rule come out right.
 
-**2. Use your parser's full-traversal visitor, not a hand-written recursion.**
+**2. Emit one `NullGuard` per explicit source-level guard.** Optional chaining
+such as `a?.b?.c` has two guards, even if the parser wraps the whole chain in a
+single container. Conversely, do not emit `NullGuard` for nullable types,
+unwraps, ordinary null comparisons, or coalescing operators (`??`, elvis,
+`orelse`); those either carry no score or remain `Logical::Coalesce`.
+
+**3. Use your parser's full-traversal visitor, not a hand-written recursion.**
 If your parser offers a visitor with default "walk every child" methods (oxc's
 `Visit`, `syn::visit`, tree-sitter cursors, …), **use it** and override only the
 nodes that produce IR. Hand-rolling a recursive `match` that enumerates node
@@ -273,6 +280,7 @@ toward the file totals but are not reported as a function).
 | `Catch { body }` | Exception handler. | +1 +nesting | +1 |
 | `Jump { labeled }` | `break`/`continue`. | +1 if `labeled`, else 0 | — |
 | `Logical { op, operands }` | One folded run of like operators. | +1 per node | +1 per *extra* operand (`operands.len() - 1`) |
+| `NullGuard { body }` | A continuation or collection contribution skipped when its input is null. Emit one node per explicit null guard; coalescing remains `Logical`. | 0 | +1 |
 | `Call { callee }` | A call. | +1 if `callee` == nearest enclosing function's `name` (recursion) | — |
 | `Group(children)` | Transparent container; recurse only. | 0 | 0 |
 


### PR DESCRIPTION
## Summary

- add `Node::NullGuard` to the language-agnostic complexity IR
- count each explicit null-dependent guard as one cyclomatic path without adding cognitive complexity or nesting
- lower equivalent constructs from ECMAScript/TypeScript, PHP, Ruby, Kotlin, and Swift
- document the cross-language contract and add conformance tests for chained guards

## Motivation

Null-safe access and optional chaining introduce an implicit control-flow split: evaluation continues when the receiver is present and skips the guarded continuation when it is absent. These paths were previously traversed transparently, so cccc did not account for them.

The existing IR variants cannot represent this accurately:

- `Group` adds no complexity
- `Branch` and `Conditional` also add cognitive complexity and nesting
- `Logical` adds cognitive complexity and uses operand-count-based cyclomatic scoring

A semantic IR node keeps language adapters free of scoring policy while allowing the core engine to model the additional execution path once for every language.

This treatment is consistent with ESLint, which documents two additional branches for `a?.b?.c`, and DCM, which counts Dart null-aware operators as cyclomatic decisions:

- https://eslint.org/docs/latest/rules/complexity
- https://dcm.dev/docs/metrics/function/cyclomatic-complexity/

## Semantics

```rust
Node::NullGuard { body: Vec<Node> }
```

For each explicit source-level guard, the core engine:

- adds one cyclomatic point
- adds no cognitive complexity
- does not increase nesting
- walks nested IR nodes normally

For example, `a?.b?.c` produces two `NullGuard` nodes.

Null coalescing remains `Node::Logical` with `LogicalOp::Coalesce`. Nullable types, unwraps, ordinary null comparisons, and coalescing operators do not emit `NullGuard`.

## Naming: `NullGuard` vs. `ImplicitNullBranch`

`ImplicitNullBranch` was considered because the construct creates an implicit branch in the control-flow graph. `NullGuard` was chosen instead for the following reasons:

- `Node::Branch` already represents structured branches that add cognitive complexity and nesting; using `Branch` in this variant's name would suggest the same contract even though `NullGuard` is cyclomatic-only
- the source-level guard is explicit (`?.`, `?->`, `&.`, and similar syntax), while only the resulting CFG branch is implicit, so `ImplicitNullBranch` can be read ambiguously
- `NullGuard` describes the semantic operation rather than its scoring consequence: a continuation or collection contribution proceeds only when a value is present
- the name also covers Dart null-aware spreads and collection elements, where navigation- or branch-specific terminology would be too narrow

Names based on a particular language's surface syntax, such as `OptionalChaining` or `SafeNavigation`, were avoided because the IR is shared across languages and must also cover non-navigation constructs.

## Language coverage

- ECMAScript/TypeScript optional members, indexes, private fields, and calls
- PHP nullsafe property and method access
- Ruby safe-navigation calls
- Kotlin safe-call navigation suffixes
- Swift optional member access, subscripts, and function calls

Dart null-aware access and collection elements will use the same IR in a follow-up PR.

## Compatibility

`Node` is a public enum. Adding `Node::NullGuard` is a source-level API change for downstream exhaustive matches and should be called out in the release notes.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
