### PR TITLE
Parallelize file discovery

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -81,9 +81,10 @@ eslint `1806.7 1786.0 1788.2 1807.4 1838.0`.
 ## Why cccc is fast
 
 Native Rust binary over the oxc parser (one of the fastest JS/TS parsers); a
-single AST pass computes both metrics together; files are analyzed across cores
-(rayon, with a small-corpus sequential fast path); output is streamed through a
-buffered writer; negligible startup vs Node/Python interpreter boot.
+single AST pass computes both metrics together; file discovery fans out across
+cores (the same parallel walker ripgrep uses) and so does analysis (rayon, with
+a small-corpus sequential fast path); output is streamed through a buffered
+writer; negligible startup vs Node/Python interpreter boot.
 
 ## Why cccc is (a bit) slower than scc
 
@@ -105,6 +106,33 @@ Profiling the remaining cost found two things worth noting:
   through a single buffered, locked writer instead of a `println!` per row
   (~6,000 rows), cutting `--table` on the zod corpus from ~17 ms to ~14 ms. JSON
   is serialized straight into the buffered writer (no intermediate `String`).
+
+## Update (2026-07-18): parallel file discovery
+
+File discovery used to walk the tree on one thread and pay two avoidable
+syscalls per file: a `canonicalize` (only needed to dedup overlapping roots)
+and a second `stat` to confirm the entry is a file. The walk now fans out
+across the `--jobs` worker count using `ignore`'s parallel walker (the one
+ripgrep uses), the file-type check reuses what the walker already knows, and
+canonicalization runs only when multiple roots could actually overlap. Output
+is byte-identical: reports are sorted by path before rendering, so the
+nondeterministic walk order never reaches the user.
+
+Measured on the same machine (Apple M4 Pro, 12 cores), median of 5 runs after
+1 warmup, default flags:
+
+| corpus | files | before | after | speedup |
+|--------|------:|-------:|------:|--------:|
+| zod `packages/zod/src` (TS) | 286 | 15.5 ms | **12.6 ms** | 1.2× |
+| VS Code (TS/JS, ~0.7M LOC) | 2,976 | 216 ms | **108 ms** | 2.0× |
+| Kubernetes (Go, ~5.2M LOC) | 17,518 | 1,711 ms | **914 ms** | 1.9× |
+| PostgreSQL (C, ~1.8M LOC) | 2,953 | 777 ms | **547 ms** | 1.4× |
+
+The gain grows with tree size because discovery is a fixed cost paid before
+any parsing starts: on Kubernetes the walk alone dropped from ~453 ms to
+~109 ms. The four-tool comparison tables above still show the original
+15.5 ms figure — those numbers come from one internally consistent run of the
+comparison harness, and only cccc has been re-measured here.
 
 ## Caveats
 

--- a/crates/cccc-cli/src/lib.rs
+++ b/crates/cccc-cli/src/lib.rs
@@ -158,19 +158,20 @@ pub fn run() -> i32 {
         }
     };
 
-    let files = walk::collect_files(&cli.paths, &exts, no_ignore, exclude.as_ref());
-    if files.is_empty() {
-        eprintln!("cccc: no matching files found");
-        return 0;
-    }
-
     // `--jobs` caps the worker count; without it we fall back to the number of
-    // logical CPUs (1 if that can't be determined).
+    // logical CPUs (1 if that can't be determined). Resolved before discovery
+    // because the directory walk fans out across the same worker count.
     let jobs = jobs_opt.map(|j| j as usize).unwrap_or_else(|| {
         std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(1)
     });
+
+    let files = walk::collect_files(&cli.paths, &exts, no_ignore, exclude.as_ref(), jobs);
+    if files.is_empty() {
+        eprintln!("cccc: no matching files found");
+        return 0;
+    }
 
     // For a handful of files, spinning up a rayon pool costs more than it saves,
     // so analyze sequentially. Above the threshold, fan out across `jobs` workers.

--- a/crates/cccc-cli/src/walk.rs
+++ b/crates/cccc-cli/src/walk.rs
@@ -2,9 +2,10 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
-use ignore::WalkBuilder;
+use ignore::{WalkBuilder, WalkState};
 
 fn has_ext(path: &Path, exts: &[String]) -> bool {
     path.extension()
@@ -54,20 +55,25 @@ fn is_excluded(path: &Path, base: Option<&Path>, exclude: Option<&GlobSet>) -> b
 /// regardless of extension; directories are walked (respecting ignore files
 /// unless `no_ignore`) and filtered by `exts`. `node_modules` is always skipped.
 /// Any file matching `exclude` is dropped, whether named explicitly or found by
-/// walking.
+/// walking. Directories are walked with up to `threads` workers; the returned
+/// order is unspecified (reports are sorted by path before rendering).
 pub fn collect_files(
     paths: &[PathBuf],
     exts: &[String],
     no_ignore: bool,
     exclude: Option<&GlobSet>,
+    threads: usize,
 ) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let mut seen = HashSet::new();
+    // Canonicalizing (a syscall per file) exists only to dedup overlapping
+    // roots; a single root cannot yield the same file twice, so skip it then.
+    let dedup = paths.len() > 1;
 
     for root in paths {
         if root.is_file() {
             if !is_excluded(root, None, exclude) {
-                push_unique(root, &mut out, &mut seen);
+                push_unique(root, dedup, &mut out, &mut seen);
             }
             continue;
         }
@@ -79,23 +85,152 @@ pub fn collect_files(
             .git_exclude(!no_ignore)
             .ignore(!no_ignore)
             .hidden(false)
+            .threads(threads)
             .filter_entry(|entry| entry.file_name() != "node_modules");
 
-        for result in builder.build() {
-            let Ok(entry) = result else { continue };
-            let path = entry.path();
-            if path.is_file() && has_ext(path, exts) && !is_excluded(path, Some(root), exclude) {
-                push_unique(path, &mut out, &mut seen);
-            }
+        let collected: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+        builder.build_parallel().run(|| {
+            Box::new(|result| {
+                let Ok(entry) = result else {
+                    return WalkState::Continue;
+                };
+                // The walker already knows the entry's type; `Path::is_file`
+                // would stat every entry a second time.
+                if entry.file_type().is_some_and(|ft| ft.is_file()) {
+                    let path = entry.path();
+                    if has_ext(path, exts) && !is_excluded(path, Some(root), exclude) {
+                        collected.lock().unwrap().push(path.to_path_buf());
+                    }
+                }
+                WalkState::Continue
+            })
+        });
+        for path in collected.into_inner().unwrap() {
+            push_unique(&path, dedup, &mut out, &mut seen);
         }
     }
 
     out
 }
 
-fn push_unique(path: &Path, out: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
-    let key = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    if seen.insert(key) {
-        out.push(path.to_path_buf());
+fn push_unique(path: &Path, dedup: bool, out: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+    if dedup {
+        let key = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        if !seen.insert(key) {
+            return;
+        }
+    }
+    out.push(path.to_path_buf());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Create a fresh, empty temp tree for one test.
+    fn temp_tree(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(name);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn ts_exts() -> Vec<String> {
+        vec!["ts".to_string()]
+    }
+
+    /// File names of the collected paths, sorted for order-independent asserts
+    /// (the parallel walk returns files in an unspecified order).
+    fn sorted_names(files: &[PathBuf]) -> Vec<String> {
+        let mut names: Vec<String> = files
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn walks_a_single_root_filtering_by_extension() {
+        let dir = temp_tree("cccc_walk_single_root");
+        fs::create_dir_all(dir.join("sub")).unwrap();
+        fs::write(dir.join("a.ts"), "").unwrap();
+        fs::write(dir.join("sub/b.ts"), "").unwrap();
+        fs::write(dir.join("sub/skip.txt"), "").unwrap();
+
+        let files = collect_files(std::slice::from_ref(&dir), &ts_exts(), false, None, 8);
+        assert_eq!(sorted_names(&files), ["a.ts", "b.ts"]);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn duplicate_roots_are_deduped() {
+        let dir = temp_tree("cccc_walk_dup_roots");
+        fs::write(dir.join("a.ts"), "").unwrap();
+
+        let files = collect_files(&[dir.clone(), dir.clone()], &ts_exts(), false, None, 8);
+        assert_eq!(sorted_names(&files), ["a.ts"]);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn nested_overlapping_roots_are_deduped() {
+        let dir = temp_tree("cccc_walk_nested_roots");
+        fs::create_dir_all(dir.join("sub")).unwrap();
+        fs::write(dir.join("a.ts"), "").unwrap();
+        fs::write(dir.join("sub/b.ts"), "").unwrap();
+
+        // `sub/b.ts` is reachable from both roots but must be counted once.
+        let files = collect_files(&[dir.clone(), dir.join("sub")], &ts_exts(), false, None, 8);
+        assert_eq!(sorted_names(&files), ["a.ts", "b.ts"]);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn explicit_file_overlapping_a_walked_root_is_deduped() {
+        let dir = temp_tree("cccc_walk_file_and_root");
+        fs::write(dir.join("a.ts"), "").unwrap();
+
+        let files = collect_files(&[dir.clone(), dir.join("a.ts")], &ts_exts(), false, None, 8);
+        assert_eq!(sorted_names(&files), ["a.ts"]);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_root_is_deduped() {
+        let dir = temp_tree("cccc_walk_symlink_roots");
+        let real = dir.join("real");
+        let link = dir.join("link");
+        fs::create_dir_all(&real).unwrap();
+        fs::write(real.join("a.ts"), "").unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        // The same file is reachable under two different paths; canonicalization
+        // must collapse them to one entry.
+        let files = collect_files(&[real, link], &ts_exts(), false, None, 8);
+        assert_eq!(sorted_names(&files), ["a.ts"]);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn single_thread_finds_the_same_files_as_parallel() {
+        let dir = temp_tree("cccc_walk_thread_count");
+        for sub in ["x", "y", "z"] {
+            fs::create_dir_all(dir.join(sub)).unwrap();
+            for f in ["a.ts", "b.ts"] {
+                fs::write(dir.join(sub).join(f), "").unwrap();
+            }
+        }
+
+        let one = collect_files(std::slice::from_ref(&dir), &ts_exts(), false, None, 1);
+        let many = collect_files(std::slice::from_ref(&dir), &ts_exts(), false, None, 8);
+        let sort = |mut v: Vec<PathBuf>| {
+            v.sort();
+            v
+        };
+        assert_eq!(sort(one), sort(many));
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/crates/cccc-cli/tests/cli.rs
+++ b/crates/cccc-cli/tests/cli.rs
@@ -185,6 +185,39 @@ fn exclude_glob_prunes_a_directory_subtree() {
 }
 
 #[test]
+fn report_files_are_sorted_by_path_despite_parallel_walk() {
+    let dir = std::env::temp_dir().join("cccc_sorted_output_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    // Enough files spread over subdirectories that an unsorted parallel walk
+    // would almost surely surface out of order.
+    for sub in ["a", "b", "c", "d", "e"] {
+        std::fs::create_dir_all(dir.join(sub)).unwrap();
+        for name in ["m.ts", "n.ts", "o.ts", "p.ts"] {
+            std::fs::write(dir.join(sub).join(name), "function f() { return 1; }").unwrap();
+        }
+    }
+
+    let out = Command::cargo_bin("cccc")
+        .unwrap()
+        .arg(&dir)
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let paths: Vec<&str> = v["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["path"].as_str().unwrap())
+        .collect();
+    assert_eq!(paths.len(), 20);
+    let mut sorted = paths.clone();
+    sorted.sort_unstable();
+    assert_eq!(paths, sorted, "files must be ordered by path");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn exclude_applies_to_explicit_file_argument() {
     Command::cargo_bin("cccc")
         .unwrap()


### PR DESCRIPTION
Walk directories with ignore's parallel walker (the one ripgrep uses), sized by the same resolved --jobs count as analysis. Two per-file syscalls also disappear: the file-type check reuses what the walker already knows instead of re-stat()ing, and canonicalize (needed only to dedup overlapping roots) is skipped for the common single-root case.

The walk order becomes nondeterministic, but reports are sorted by path before rendering, so output is byte-identical (verified against the previous binary on VS Code / Kubernetes / PostgreSQL trees).

Full-scan medians on an M4 Pro: zod 15.5->12.6 ms, VS Code 216->108 ms, Kubernetes 1,711->914 ms, PostgreSQL 777->547 ms. On Kubernetes the walk alone drops from ~453 ms to ~109 ms. BENCHMARK.md records the details.