### PR TITLE
Reduce release binary size with panic=abort and opt-level=s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,5 @@ serde = { version = "1", features = ["derive"] }
 lto = true
 codegen-units = 1
 strip = true
+panic = "abort"
+opt-level = "s"


### PR DESCRIPTION
Shrinks the release binary from 23,587,040 to 21,669,968 bytes (-8.1%) with no measurable runtime cost: analysis output on the zod benchmark corpus is byte-identical and the median wall-clock time stays within noise (17.4ms -> 18.0ms). opt-level="z" was evaluated too (-11.8%) but rejected because it slowed analysis by ~27%.