### PR TITLE
Make JSON output compact by default, add --pretty

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ directories are walked recursively (respecting `.gitignore`, always skipping
 extension, so a directory mixing `.ts`, `.rs`, `.go`, and `.php` is analyzed in
 a single run. Restrict the languages with `--lang` (e.g. `--lang go,rust`).
 
-Output is **JSON by default**.
+Output is **JSON by default** — compact, on one line, ready to pipe into `jq`
+or an artifact store; `--pretty` prints the same document indented.
 
 ### Options
 
@@ -146,6 +147,7 @@ Output is **JSON by default**.
 | `--top-cognitive N` | Show only the N most cognitively-complex functions, as a flat cross-file ranking |
 | `--top-cyclomatic N` | Show only the N most cyclomatically-complex functions, as a flat cross-file ranking |
 | `--no-ignore` | Do not respect `.gitignore` when walking directories |
+| `--pretty` | Pretty-print the JSON output (default is compact, one line) |
 | `-j, --jobs N` | Number of files to analyze in parallel (default: logical CPU count) |
 
 ### Configuration file
@@ -169,6 +171,7 @@ max-cyclomatic = 10
 min           = 1
 no-ignore     = false
 jobs          = 8
+pretty        = false               # indented JSON instead of the compact default
 
 # Per-language extension overrides. Each entry replaces that language's default
 # extensions (and routes those extensions to it). Keyed by a language's name or

--- a/crates/cccc-cli/src/cli.rs
+++ b/crates/cccc-cli/src/cli.rs
@@ -81,6 +81,10 @@ pub struct Cli {
     #[arg(long)]
     pub no_ignore: bool,
 
+    /// Pretty-print the JSON output (the default is compact, one line).
+    #[arg(long)]
+    pub pretty: bool,
+
     /// Number of files to analyze in parallel. Defaults to the number of
     /// available logical CPUs.
     #[arg(short = 'j', long, value_name = "N", value_parser = clap::value_parser!(u32).range(1..))]

--- a/crates/cccc-cli/src/config.rs
+++ b/crates/cccc-cli/src/config.rs
@@ -50,6 +50,8 @@ pub struct Config {
     pub no_ignore: Option<bool>,
     /// Number of files to analyze in parallel.
     pub jobs: Option<u32>,
+    /// Pretty-print the JSON output (the default is compact, one line).
+    pub pretty: Option<bool>,
 }
 
 impl Config {

--- a/crates/cccc-cli/src/lib.rs
+++ b/crates/cccc-cli/src/lib.rs
@@ -87,6 +87,11 @@ pub fn run() -> i32 {
     } else {
         config.exclude.clone().unwrap_or_default()
     };
+    let pretty = if was_set("pretty") {
+        cli.pretty
+    } else {
+        config.pretty.unwrap_or(false)
+    };
     let max_cognitive = cli.max_cognitive.or(config.max_cognitive);
     let max_cyclomatic = cli.max_cyclomatic.or(config.max_cyclomatic);
     let min = cli.min.or(config.min);
@@ -234,7 +239,7 @@ pub fn run() -> i32 {
         if table {
             output::print_top_table(&top);
         } else {
-            output::print_json(&top);
+            output::print_json(&top, pretty);
         }
         return i32::from(fail);
     }
@@ -253,7 +258,7 @@ pub fn run() -> i32 {
     if table {
         output::print_table(&report);
     } else {
-        output::print_json(&report);
+        output::print_json(&report, pretty);
     }
 
     i32::from(fail)

--- a/crates/cccc-cli/src/output.rs
+++ b/crates/cccc-cli/src/output.rs
@@ -29,15 +29,22 @@ pub fn warn(msg: &str) {
     eprintln!("{}", yellow(msg, use_color(&std::io::stderr())));
 }
 
-/// Print any serializable value as pretty JSON to stdout.
+/// Print any serializable value as JSON to stdout — compact (one line) by
+/// default, indented with `pretty` (which costs ~40% more bytes on large
+/// reports).
 ///
 /// Serializes straight into a buffered, locked stdout writer rather than
 /// building one big `String` first — for large reports (zod's corpus is ~1 MB
 /// of JSON) that avoids materializing the whole document in memory.
-pub fn print_json<T: Serialize>(value: &T) {
+pub fn print_json<T: Serialize>(value: &T, pretty: bool) {
     let stdout = std::io::stdout();
     let mut out = std::io::BufWriter::new(stdout.lock());
-    let result = serde_json::to_writer_pretty(&mut out, value)
+    let written = if pretty {
+        serde_json::to_writer_pretty(&mut out, value)
+    } else {
+        serde_json::to_writer(&mut out, value)
+    };
+    let result = written
         .map_err(std::io::Error::from)
         .and_then(|()| out.write_all(b"\n"))
         .and_then(|()| out.flush());

--- a/crates/cccc-cli/tests/cli.rs
+++ b/crates/cccc-cli/tests/cli.rs
@@ -734,3 +734,28 @@ fn cli_unknown_language_in_ext_is_an_error() {
         .code(2)
         .stderr(predicates::str::contains("unknown language"));
 }
+
+// ----- JSON formatting -------------------------------------------------------
+
+#[test]
+fn default_json_is_compact_and_pretty_expands_it() {
+    let compact_out = Command::cargo_bin("cccc")
+        .unwrap()
+        .arg("tests/fixtures/sample.ts")
+        .assert()
+        .success();
+    let compact = String::from_utf8(compact_out.get_output().stdout.clone()).unwrap();
+    assert_eq!(compact.trim_end().lines().count(), 1, "one line of JSON");
+
+    let pretty_out = Command::cargo_bin("cccc")
+        .unwrap()
+        .args(["--pretty", "tests/fixtures/sample.ts"])
+        .assert()
+        .success();
+    let pretty = String::from_utf8(pretty_out.get_output().stdout.clone()).unwrap();
+    assert!(pretty.trim_end().lines().count() > 1, "indented JSON");
+
+    let a: serde_json::Value = serde_json::from_str(&compact).expect("valid JSON");
+    let b: serde_json::Value = serde_json::from_str(&pretty).expect("valid JSON");
+    assert_eq!(a, b, "--pretty must not change the content");
+}


### PR DESCRIPTION
The JSON output exists to be consumed by machines — jq, CI artifacts, diff tooling — where pretty-printing is pure overhead (~40% of the bytes, ~15% of the wall clock on a 17k-file tree). Emit one line by default and keep the indented form behind --pretty (config key `pretty`) for humans reading it directly.

Breaking change for consumers that relied on the indented default; the document itself is unchanged.