### PR TITLE
Add a results cache (--cache) for unchanged files

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -152,3 +152,82 @@ verify-then-time script). Build cccc with `cargo build --release`; install scc
 (`brew install scc`), lizard (`pip install lizard`), and the Node tools
 (`npm install eslint@8 @typescript-eslint/parser eslint-plugin-sonarjs`). Run
 `python3 timeit.py`.
+
+---
+
+# Benchmark: the results cache (`--cache`)
+
+The results cache reuses the previous run's per-file scores for files whose
+size/mtime are unchanged (still validated per entry against the analyzing
+language and the cccc version), re-analyzing only what changed. These numbers
+size what that buys on real monorepos, per language front-end.
+
+## Corpora
+
+Shallow clones, analyzed at the repository root:
+
+| Corpus | Front-end | Files | Functions |
+|--------|-----------|------:|----------:|
+| [microsoft/vscode](https://github.com/microsoft/vscode) (TS/JS) | oxc | 2,976 | 49,087 |
+| [kubernetes/kubernetes](https://github.com/kubernetes/kubernetes) (Go) | gosyn | 17,518 | 214,354 |
+| [postgres/postgres](https://github.com/postgres/postgres) (C) | tree-sitter | 2,953 | 27,299 |
+
+## Method
+
+Same machine as above (Apple M4 Pro, 12 cores; release build). Each cell is the
+median of 5 runs after 1 warmup, stdout to `/dev/null`. Scenarios:
+
+- **cold** — no cache (`cccc <repo>`).
+- **warm, all hits** — a populated cache, nothing changed.
+- **warm + `--pretty`** — same, with pretty-printed instead of the default
+  single-line JSON.
+- **1% changed** — before every run, 1% of the files (26 / 175 / 25) are
+  appended to, so each run re-analyzes those and reuses the rest.
+
+Cached output was verified byte-for-byte identical to a cold run on all three
+corpora before timing.
+
+## Results — wall clock, median ms
+
+| Corpus | cold | warm (all hits) | warm + `--pretty` | 1% changed | warm vs cold |
+|--------|-----:|----------------:|------------------:|-----------:|-------------:|
+| vscode (TS/JS) | 101.0 | 37.2 | 43.1 | 44.7 | **2.7×** |
+| kubernetes (Go) | 868.2 | 168.6 | 187.3 | 212.0 | **5.1×** |
+| postgres (C) | 549.3 | 31.1 | 33.3 | 67.5 | **17.7×** |
+
+Cache file sizes: vscode 3.9 MB, kubernetes 20 MB, postgres 3.1 MB.
+
+## Reading the results
+
+- **The win scales with per-file parse cost.** tree-sitter front-ends (C here;
+  also Java, Kotlin, Python, Swift, Dart, Perl) parse ~5× slower per line than
+  oxc, so they gain the most (~18×). oxc is fast enough that TS/JS gains only
+  ~2.7× — the remaining time isn't analysis at all.
+- **Warm runs are floored by discovery + output, not by the cache.** Phase
+  timing on the kubernetes warm run put the gitignore-aware directory walk at
+  ~100 ms and JSON rendering at ~28 ms (~50 ms with `--pretty`), while all
+  cache work combined — loading the index, 17.5k stats, decoding hit entries —
+  is ~26 ms. The cache's own format matters little at this point: only the
+  index is decoded on load, and each hit decodes just its own entry, in
+  parallel.
+- **The realistic steady state is "a few files changed".** That scenario stays
+  well below the cold cost on every corpus (1.2–2.2× the all-hit floor):
+  invalidation is stat-only, and re-analysis is proportional to what changed
+  (plus one cache rewrite).
+- **When not to bother:** small trees (a cold zod-sized run is already ~15 ms)
+  and one-shot CI runs where restoring/saving a 4–20 MB cache artifact costs
+  more than the 0.1–0.7 s it saves. The cache is off by default for a reason;
+  it pays off for repeated local runs — watch loops, pre-commit hooks, editor
+  integrations — on large trees.
+
+## Reproduce
+
+```sh
+cargo build --release
+git clone --depth 1 https://github.com/kubernetes/kubernetes /tmp/k8s
+# cold
+target/release/cccc --no-config /tmp/k8s > /dev/null
+# populate, then warm
+target/release/cccc --no-config --cache-file /tmp/k8s.cache /tmp/k8s > /dev/null
+target/release/cccc --no-config --cache-file /tmp/k8s.cache /tmp/k8s > /dev/null
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +218,7 @@ name = "cccc-cli"
 version = "1.5.0"
 dependencies = [
  "assert_cmd",
+ "bincode",
  "cccc-c",
  "cccc-clojure",
  "cccc-core",

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ or an artifact store; `--pretty` prints the same document indented.
 | `--top-cognitive N` | Show only the N most cognitively-complex functions, as a flat cross-file ranking |
 | `--top-cyclomatic N` | Show only the N most cyclomatically-complex functions, as a flat cross-file ranking |
 | `--no-ignore` | Do not respect `.gitignore` when walking directories |
+| `--cache` | Cache results and reuse them for files unchanged since the last run |
+| `--cache-file PATH` | Where to keep the results cache (implies `--cache`). Default: `.cccc.cache` next to the config file, or in the current directory |
+| `--no-cache` | Do not use the results cache, even if the config file enables it |
 | `--pretty` | Pretty-print the JSON output (default is compact, one line) |
 | `-j, --jobs N` | Number of files to analyze in parallel (default: logical CPU count) |
 
@@ -172,6 +175,8 @@ min           = 1
 no-ignore     = false
 jobs          = 8
 pretty        = false               # indented JSON instead of the compact default
+cache         = false               # reuse results for unchanged files
+cache-file    = ".cccc.cache"       # cache location (does not enable by itself)
 
 # Per-language extension overrides. Each entry replaces that language's default
 # extensions (and routes those extensions to it). Keyed by a language's name or
@@ -203,6 +208,23 @@ use `**` to span directories. Brace alternation is supported, e.g.
 directory or named explicitly on the command line. An invalid pattern is an error
 (exit code 2). This is independent of `--no-ignore` and `.gitignore` handling.
 
+### Results cache
+
+For continuous measurement — watch loops, pre-commit hooks, editor
+integrations — `--cache` (or `cache = true` in `cccc.toml`) makes repeat runs
+reuse the previous results for files that haven't changed, re-analyzing only
+what did. On large monorepos this cuts warm runs by ~2.7× (TS/JS) to ~18×
+(tree-sitter languages such as C) — measured numbers are in
+[BENCHMARK.md](BENCHMARK.md) — and the output is byte-for-byte identical to an
+uncached run.
+
+An entry is reused only if the file's size and mtime are unchanged, the same
+language still claims its extension, and the cache was written by the same
+`cccc` version — anything else (including a missing or corrupt cache file) just
+means that file is analyzed fresh. The cache lives in `.cccc.cache` next to the
+config file (so runs from any subdirectory share it), or where `--cache-file`
+points; add it to `.gitignore`.
+
 ### Examples
 
 ```sh
@@ -232,6 +254,9 @@ cccc --exclude 'dist/**' --exclude '**/*.{test,spec}.ts' src/
 
 # Limit parallelism to 4 workers (default is the logical CPU count)
 cccc -j 4 src/
+
+# Recurring runs: reuse results for files unchanged since the last run
+cccc --cache src/
 ```
 
 Files are analyzed in parallel. The worker count defaults to the number of

--- a/crates/cccc-cli/Cargo.toml
+++ b/crates/cccc-cli/Cargo.toml
@@ -35,6 +35,7 @@ globset = "0.4"
 ignore = "0.4"
 serde = { workspace = true }
 serde_json = "1"
+bincode = "1"
 toml = "1.1"
 rayon = "1"
 

--- a/crates/cccc-cli/src/cache.rs
+++ b/crates/cccc-cli/src/cache.rs
@@ -1,0 +1,298 @@
+//! On-disk results cache: skip re-analyzing files that haven't changed.
+//!
+//! Analysis is a pure function of a file's content and the language front-end
+//! that handles it, so a cached [`FileReport`] can be reused as long as neither
+//! changed. An entry is validated by (size, mtime) — stat-level checks, no file
+//! read — plus the canonical name of the language that produced it (extension
+//! re-routing via `--ext`/`[ext]` must not resurface another language's scores).
+//! The whole cache is stamped with the cccc version, since counting rules can
+//! change between releases.
+//!
+//! ## File layout
+//!
+//! `bincode(version, index, blobs)`, where `index` maps each path to its
+//! validation signature and a byte range into `blobs`, and `blobs` is the
+//! concatenation of one independently-encoded blob per file. On load only the
+//! index is decoded; each hit decodes just its own blob, in parallel on the
+//! analysis thread pool. Warm-run overhead is thus "stat + decode what you
+//! use", regardless of cache size.
+//!
+//! Any unreadable, corrupt, or version-mismatched cache file degrades to a
+//! cold run — the cache is an accelerator, never a source of errors.
+//!
+//! [`FileReport`] is serialized through mirror types: its `skip_serializing_if`
+//! attributes would corrupt a non-self-describing format like bincode (a
+//! skipped field shifts every later byte of the stream).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rayon::prelude::*;
+
+use cccc_core::report::{FileReport, FunctionReport};
+
+/// Entries are only valid for the exact version that wrote them.
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Validation signature plus blob location for one cached file.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct IndexEntry {
+    /// Canonical name of the language that analyzed the file.
+    lang: String,
+    size: u64,
+    mtime_ns: u128,
+    offset: u64,
+    len: u64,
+}
+
+/// Mirror of [`FunctionReport`] without `skip_serializing_if` (see module doc).
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CacheFun {
+    name: String,
+    kind: String,
+    line: u32,
+    cognitive: u32,
+    cyclomatic: u32,
+    children: Vec<CacheFun>,
+}
+
+/// Mirror of [`FileReport`] without `skip_serializing_if` (see module doc).
+#[derive(serde::Serialize, serde::Deserialize)]
+struct CacheReport {
+    path: String,
+    cognitive: u32,
+    cyclomatic: u32,
+    functions: Vec<CacheFun>,
+    parse_errors: Vec<String>,
+}
+
+/// A loaded cache: the lookup index plus the raw, still-encoded entry blobs.
+pub struct Cache {
+    index: HashMap<String, IndexEntry>,
+    blobs: Vec<u8>,
+}
+
+/// Load the cache at `path`. Returns `None` — a cold run — when the file is
+/// missing, unreadable, corrupt, or written by a different cccc version.
+pub fn load(path: &Path) -> Option<Cache> {
+    let bytes = std::fs::read(path).ok()?;
+    let (version, index, blobs): (String, Vec<(String, IndexEntry)>, Vec<u8>) =
+        bincode::deserialize(&bytes).ok()?;
+    if version != VERSION {
+        return None;
+    }
+    Some(Cache {
+        index: index.into_iter().collect(),
+        blobs,
+    })
+}
+
+impl Cache {
+    /// The cached report for `path`, if the file still matches its recorded
+    /// signature and is still analyzed by `lang`.
+    pub fn lookup(&self, path: &Path, lang: &str) -> Option<FileReport> {
+        let entry = self.index.get(&path.display().to_string())?;
+        if entry.lang != lang || file_sig(path)? != (entry.size, entry.mtime_ns) {
+            return None;
+        }
+        let blob = self
+            .blobs
+            .get(entry.offset as usize..(entry.offset + entry.len) as usize)?;
+        let report: CacheReport = bincode::deserialize(blob).ok()?;
+        Some(from_cache(report))
+    }
+}
+
+/// Write a fresh cache for `reports` to `path`, replacing any previous file.
+/// `lang_for` names the language that analyzed a path (entries it can't name
+/// are simply not cached). Encoding fans out on the current rayon pool; a
+/// failed write only costs the next run its warm start, so it warns rather
+/// than failing the process.
+pub fn store(
+    path: &Path,
+    reports: &[FileReport],
+    lang_for: &(dyn Fn(&Path) -> Option<&'static str> + Sync),
+) {
+    let encoded: Vec<(String, IndexEntry, Vec<u8>)> = reports
+        .par_iter()
+        .filter_map(|r| {
+            let file = Path::new(&r.path);
+            let lang = lang_for(file)?;
+            let (size, mtime_ns) = file_sig(file)?;
+            let blob = bincode::serialize(&to_cache(r)).ok()?;
+            let entry = IndexEntry {
+                lang: lang.to_string(),
+                size,
+                mtime_ns,
+                offset: 0, // fixed up below, once concatenation order is known
+                len: blob.len() as u64,
+            };
+            Some((r.path.clone(), entry, blob))
+        })
+        .collect();
+
+    let mut index = Vec::with_capacity(encoded.len());
+    let mut blobs = Vec::new();
+    for (key, mut entry, blob) in encoded {
+        entry.offset = blobs.len() as u64;
+        blobs.extend_from_slice(&blob);
+        index.push((key, entry));
+    }
+
+    let Ok(bytes) = bincode::serialize(&(VERSION, index, blobs)) else {
+        crate::output::warn("cccc: warning: failed to encode results cache");
+        return;
+    };
+    // Write-then-rename so an interrupted run cannot leave a torn cache file.
+    let Some(name) = path.file_name() else { return };
+    let tmp = path.with_file_name(format!("{}.tmp", name.to_string_lossy()));
+    let written = std::fs::write(&tmp, &bytes).and_then(|()| std::fs::rename(&tmp, path));
+    if let Err(e) = written {
+        crate::output::warn(&format!(
+            "cccc: warning: failed to write results cache {}: {e}",
+            path.display()
+        ));
+    }
+}
+
+/// Stat `path` into its cache-validation signature.
+fn file_sig(path: &Path) -> Option<(u64, u128)> {
+    let md = std::fs::metadata(path).ok()?;
+    let mtime = md
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_nanos();
+    Some((md.len(), mtime))
+}
+
+fn to_cache_funs(fns: &[FunctionReport]) -> Vec<CacheFun> {
+    fns.iter()
+        .map(|f| CacheFun {
+            name: f.name.clone(),
+            kind: f.kind.clone(),
+            line: f.line,
+            cognitive: f.cognitive,
+            cyclomatic: f.cyclomatic,
+            children: to_cache_funs(&f.children),
+        })
+        .collect()
+}
+
+fn from_cache_funs(fns: Vec<CacheFun>) -> Vec<FunctionReport> {
+    fns.into_iter()
+        .map(|f| FunctionReport {
+            name: f.name,
+            kind: f.kind,
+            line: f.line,
+            cognitive: f.cognitive,
+            cyclomatic: f.cyclomatic,
+            children: from_cache_funs(f.children),
+        })
+        .collect()
+}
+
+fn to_cache(r: &FileReport) -> CacheReport {
+    CacheReport {
+        path: r.path.clone(),
+        cognitive: r.cognitive,
+        cyclomatic: r.cyclomatic,
+        functions: to_cache_funs(&r.functions),
+        parse_errors: r.parse_errors.clone(),
+    }
+}
+
+fn from_cache(c: CacheReport) -> FileReport {
+    FileReport {
+        path: c.path,
+        cognitive: c.cognitive,
+        cyclomatic: c.cyclomatic,
+        functions: from_cache_funs(c.functions),
+        parse_errors: c.parse_errors,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_report(path: &str) -> FileReport {
+        FileReport {
+            path: path.to_string(),
+            cognitive: 3,
+            cyclomatic: 2,
+            functions: vec![FunctionReport {
+                name: "f".to_string(),
+                kind: "function".to_string(),
+                line: 1,
+                cognitive: 3,
+                cyclomatic: 2,
+                children: vec![FunctionReport {
+                    name: "g".to_string(),
+                    kind: "arrow".to_string(),
+                    line: 2,
+                    cognitive: 0,
+                    cyclomatic: 1,
+                    children: Vec::new(),
+                }],
+            }],
+            parse_errors: vec!["boom".to_string()],
+        }
+    }
+
+    #[test]
+    fn roundtrip_hits_for_unchanged_file() {
+        let dir = std::env::temp_dir().join("cccc_cache_unit_roundtrip");
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("a.ts");
+        std::fs::write(&src, "function f() {}").unwrap();
+        let cache_file = dir.join("cache.bin");
+
+        let report = sample_report(&src.display().to_string());
+        store(&cache_file, &[report], &|_| Some("es"));
+
+        let cache = load(&cache_file).expect("cache loads");
+        let hit = cache.lookup(&src, "es").expect("unchanged file hits");
+        assert_eq!(hit.cognitive, 3);
+        assert_eq!(hit.functions[0].children[0].name, "g");
+        assert_eq!(hit.parse_errors, vec!["boom".to_string()]);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn changed_file_and_changed_language_miss() {
+        let dir = std::env::temp_dir().join("cccc_cache_unit_invalidate");
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("a.ts");
+        std::fs::write(&src, "function f() {}").unwrap();
+        let cache_file = dir.join("cache.bin");
+
+        store(
+            &cache_file,
+            &[sample_report(&src.display().to_string())],
+            &|_| Some("es"),
+        );
+        let cache = load(&cache_file).unwrap();
+        assert!(
+            cache.lookup(&src, "rust").is_none(),
+            "other language misses"
+        );
+
+        std::fs::write(&src, "function f() { return 1 }").unwrap();
+        assert!(cache.lookup(&src, "es").is_none(), "changed file misses");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn corrupt_cache_degrades_to_cold() {
+        let dir = std::env::temp_dir().join("cccc_cache_unit_corrupt");
+        std::fs::create_dir_all(&dir).unwrap();
+        let cache_file = dir.join("cache.bin");
+        std::fs::write(&cache_file, b"not a cache").unwrap();
+        assert!(load(&cache_file).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/cccc-cli/src/cli.rs
+++ b/crates/cccc-cli/src/cli.rs
@@ -81,6 +81,20 @@ pub struct Cli {
     #[arg(long)]
     pub no_ignore: bool,
 
+    /// Cache results and reuse them for files unchanged since the last run.
+    /// The cache lives in `.cccc.cache` next to the config file (or in the
+    /// current directory without one) unless `--cache-file` says otherwise.
+    #[arg(long)]
+    pub cache: bool,
+
+    /// Where to keep the results cache (implies `--cache`).
+    #[arg(long, value_name = "PATH")]
+    pub cache_file: Option<PathBuf>,
+
+    /// Do not use the results cache, even if the config file enables it.
+    #[arg(long, conflicts_with_all = ["cache", "cache_file"])]
+    pub no_cache: bool,
+
     /// Pretty-print the JSON output (the default is compact, one line).
     #[arg(long)]
     pub pretty: bool,

--- a/crates/cccc-cli/src/config.rs
+++ b/crates/cccc-cli/src/config.rs
@@ -52,6 +52,15 @@ pub struct Config {
     pub jobs: Option<u32>,
     /// Pretty-print the JSON output (the default is compact, one line).
     pub pretty: Option<bool>,
+    /// Cache results and reuse them for files unchanged since the last run.
+    pub cache: Option<bool>,
+    /// Where to keep the results cache (default: `.cccc.cache` next to this
+    /// config file). Does not enable caching by itself.
+    pub cache_file: Option<PathBuf>,
+    /// Directory containing the loaded config file. Not a config key — filled
+    /// in at load time so the default cache location can sit beside the file.
+    #[serde(skip)]
+    pub source_dir: Option<PathBuf>,
 }
 
 impl Config {
@@ -99,7 +108,10 @@ fn find_config() -> Option<PathBuf> {
 fn load(path: &Path) -> Result<Config, String> {
     let text = std::fs::read_to_string(path)
         .map_err(|e| format!("cannot read config {}: {e}", path.display()))?;
-    toml::from_str(&text).map_err(|e| format!("invalid config {}: {e}", path.display()))
+    let mut config: Config =
+        toml::from_str(&text).map_err(|e| format!("invalid config {}: {e}", path.display()))?;
+    config.source_dir = path.parent().map(Path::to_path_buf);
+    Ok(config)
 }
 
 #[cfg(test)]

--- a/crates/cccc-cli/src/lang.rs
+++ b/crates/cccc-cli/src/lang.rs
@@ -211,7 +211,9 @@ fn unknown_language_error(name: &str, context: &str) -> String {
     )
 }
 
-/// Build an extension → analyzer map for the given languages.
+/// Build an extension → language map for the given languages (the language
+/// carries both its analyzer and its canonical name, which the results cache
+/// records per entry).
 ///
 /// Each language contributes its [`Language::exts`], unless `ext_overrides`
 /// supplies a replacement list keyed by that language's name or an alias (e.g.
@@ -221,7 +223,7 @@ fn unknown_language_error(name: &str, context: &str) -> String {
 pub fn build_dispatch(
     langs: &[&'static Language],
     ext_overrides: &BTreeMap<String, Vec<String>>,
-) -> HashMap<String, AnalyzeFn> {
+) -> HashMap<String, &'static Language> {
     let mut map = HashMap::new();
     for lang in langs {
         let exts: Vec<String> = match override_for(lang, ext_overrides) {
@@ -229,7 +231,7 @@ pub fn build_dispatch(
             None => lang.exts.iter().map(|s| s.to_ascii_lowercase()).collect(),
         };
         for ext in exts {
-            map.entry(ext).or_insert(lang.analyze);
+            map.entry(ext).or_insert(*lang);
         }
     }
     map

--- a/crates/cccc-cli/src/lib.rs
+++ b/crates/cccc-cli/src/lib.rs
@@ -7,9 +7,10 @@
 //! [`config`]); CLI flags always take precedence over it.
 //!
 //! Everything common to the languages lives here: argument parsing, config
-//! resolution, file discovery, parallel analysis, the threshold/`--min`/`--top`
-//! logic, and output rendering. Each language supplies only how to analyze one
-//! file and its default extensions, via the [`lang::LANGUAGES`] registry.
+//! resolution, file discovery, the results cache (see [`cache`]), parallel
+//! analysis, the threshold/`--min`/`--top` logic, and output rendering. Each
+//! language supplies only how to analyze one file and its default extensions,
+//! via the [`lang::LANGUAGES`] registry.
 //!
 //! ## Exit codes
 //!
@@ -22,6 +23,7 @@
 //!   value was invalid, or the worker pool could not be created. (clap's own
 //!   usage errors also exit `2`.)
 
+mod cache;
 mod cli;
 pub mod config;
 pub mod lang;
@@ -92,6 +94,27 @@ pub fn run() -> i32 {
     } else {
         config.pretty.unwrap_or(false)
     };
+    // The cache is on when the user says so (`--cache`, an explicit
+    // `--cache-file`, or `cache = true` in the config) and `--no-cache` doesn't
+    // veto it. The file defaults to `.cccc.cache` beside the config file, so a
+    // project-enabled cache lands in the same place from any subdirectory.
+    let cache_enabled = if cli.no_cache {
+        false
+    } else {
+        cli.cache || cli.cache_file.is_some() || config.cache.unwrap_or(false)
+    };
+    let cache_path: Option<std::path::PathBuf> = cache_enabled.then(|| {
+        cli.cache_file
+            .clone()
+            .or_else(|| config.cache_file.clone())
+            .unwrap_or_else(|| {
+                config
+                    .source_dir
+                    .as_deref()
+                    .unwrap_or(Path::new(""))
+                    .join(".cccc.cache")
+            })
+    });
     let max_cognitive = cli.max_cognitive.or(config.max_cognitive);
     let max_cyclomatic = cli.max_cyclomatic.or(config.max_cyclomatic);
     let min = cli.min.or(config.min);
@@ -178,28 +201,81 @@ pub fn run() -> i32 {
         return 0;
     }
 
-    // For a handful of files, spinning up a rayon pool costs more than it saves,
-    // so analyze sequentially. Above the threshold, fan out across `jobs` workers.
-    let mut reports: Vec<FileReport> = if jobs <= 1 || files.len() <= PARALLEL_THRESHOLD {
-        files
-            .iter()
-            .filter_map(|p| read_and_analyze(&dispatch, p))
-            .collect()
+    // For a handful of files, spinning up a rayon pool costs more than it
+    // saves, so run sequentially. Above the threshold one pool drives every
+    // parallel phase (cache validation, analysis, cache write-back), keeping
+    // `--jobs` an honest bound on worker count.
+    let pool = if jobs <= 1 || files.len() <= PARALLEL_THRESHOLD {
+        None
     } else {
-        let pool = match rayon::ThreadPoolBuilder::new().num_threads(jobs).build() {
-            Ok(pool) => pool,
+        match rayon::ThreadPoolBuilder::new().num_threads(jobs).build() {
+            Ok(pool) => Some(pool),
             Err(e) => {
                 eprintln!("cccc: failed to start thread pool: {e}");
                 return 2;
             }
-        };
-        pool.install(|| {
-            files
+        }
+    };
+
+    // Split the files into cache hits (report ready) and misses (to analyze).
+    // Without a usable cache everything is a miss.
+    let cache = cache_path.as_deref().and_then(cache::load);
+    let (cached_reports, to_analyze): (Vec<FileReport>, Vec<&std::path::PathBuf>) = match &cache {
+        Some(c) => {
+            let checked: Vec<Result<FileReport, &std::path::PathBuf>> = match &pool {
+                Some(pool) => pool.install(|| {
+                    files
+                        .par_iter()
+                        .map(|p| check_cached(c, &dispatch, p))
+                        .collect()
+                }),
+                None => files
+                    .iter()
+                    .map(|p| check_cached(c, &dispatch, p))
+                    .collect(),
+            };
+            let mut hits = Vec::new();
+            let mut misses = Vec::new();
+            for entry in checked {
+                match entry {
+                    Ok(report) => hits.push(report),
+                    Err(p) => misses.push(p),
+                }
+            }
+            (hits, misses)
+        }
+        None => (Vec::new(), files.iter().collect()),
+    };
+
+    let mut reports: Vec<FileReport> = match &pool {
+        Some(pool) => pool.install(|| {
+            to_analyze
                 .par_iter()
                 .filter_map(|p| read_and_analyze(&dispatch, p))
                 .collect()
-        })
+        }),
+        None => to_analyze
+            .iter()
+            .filter_map(|p| read_and_analyze(&dispatch, p))
+            .collect(),
     };
+    reports.extend(cached_reports);
+
+    // Refresh the cache — unless every file was a hit, in which case it is
+    // already exactly what we would write.
+    if let Some(cache_file) = cache_path.as_deref()
+        && !(cache.is_some() && to_analyze.is_empty())
+    {
+        let store = || {
+            cache::store(cache_file, &reports, &|p| {
+                lang_for(&dispatch, p).map(|l| l.name)
+            })
+        };
+        match &pool {
+            Some(pool) => pool.install(store),
+            None => store(),
+        }
+    }
 
     reports.sort_by(|a, b| a.path.cmp(&b.path));
 
@@ -309,17 +385,40 @@ fn split_exts(s: &str) -> Vec<String> {
 /// Read a file and analyze it with the language matching its extension,
 /// reporting (but not failing on) read errors. A file whose extension no active
 /// language claims is skipped silently (it was only collected via `--ext`).
-fn read_and_analyze(dispatch: &HashMap<String, AnalyzeFn>, path: &Path) -> Option<FileReport> {
-    let analyze = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .and_then(|e| dispatch.get(&e.to_ascii_lowercase()))?;
+fn read_and_analyze(
+    dispatch: &HashMap<String, &'static lang::Language>,
+    path: &Path,
+) -> Option<FileReport> {
+    let language = lang_for(dispatch, path)?;
     match std::fs::read_to_string(path) {
-        Ok(src) => Some(analyze(path, &src)),
+        Ok(src) => Some((language.analyze)(path, &src)),
         Err(e) => {
             eprintln!("cccc: cannot read {}: {e}", path.display());
             None
         }
+    }
+}
+
+/// The active language claiming `path`'s extension, if any does.
+fn lang_for(
+    dispatch: &HashMap<String, &'static lang::Language>,
+    path: &Path,
+) -> Option<&'static lang::Language> {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .and_then(|e| dispatch.get(&e.to_ascii_lowercase()))
+        .copied()
+}
+
+/// The cached report for `path` — or `path` itself, as a miss to analyze.
+fn check_cached<'a>(
+    cache: &cache::Cache,
+    dispatch: &HashMap<String, &'static lang::Language>,
+    path: &'a std::path::PathBuf,
+) -> Result<FileReport, &'a std::path::PathBuf> {
+    match lang_for(dispatch, path).and_then(|l| cache.lookup(path, l.name)) {
+        Some(report) => Ok(report),
+        None => Err(path),
     }
 }
 

--- a/crates/cccc-cli/tests/cli.rs
+++ b/crates/cccc-cli/tests/cli.rs
@@ -735,6 +735,79 @@ fn cli_unknown_language_in_ext_is_an_error() {
         .stderr(predicates::str::contains("unknown language"));
 }
 
+// ----- results cache ---------------------------------------------------------
+
+#[test]
+fn cache_reuses_unchanged_files_and_reanalyzes_edits() {
+    let dir = std::env::temp_dir().join("cccc_cache_cli_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("sample.ts");
+    std::fs::copy("tests/fixtures/sample.ts", &src).unwrap();
+    let cache = dir.join("cache.bin");
+
+    let run = || {
+        let out = Command::cargo_bin("cccc")
+            .unwrap()
+            .args(["--no-config", "--cache-file"])
+            .arg(&cache)
+            .arg(&dir)
+            .assert()
+            .success();
+        String::from_utf8(out.get_output().stdout.clone()).unwrap()
+    };
+
+    let cold = run();
+    assert!(cache.is_file(), "cache file is created");
+    let warm = run();
+    assert_eq!(cold, warm, "an all-hit run must not change the output");
+
+    // Editing the file must invalidate its entry.
+    let orig = std::fs::read_to_string(&src).unwrap();
+    std::fs::write(
+        &src,
+        format!("{orig}\nfunction extraFn(x: number) {{ return x ? 1 : 2; }}\n"),
+    )
+    .unwrap();
+    let edited = run();
+    assert!(edited.contains("extraFn"), "changed file is re-analyzed");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn no_cache_flag_disables_config_enabled_cache() {
+    let dir = std::env::temp_dir().join("cccc_no_cache_cli_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::copy("tests/fixtures/sample.ts", dir.join("sample.ts")).unwrap();
+    std::fs::write(dir.join("cccc.toml"), "cache = true\n").unwrap();
+
+    Command::cargo_bin("cccc")
+        .unwrap()
+        .current_dir(&dir)
+        .args(["--no-cache", "."])
+        .assert()
+        .success();
+    assert!(
+        !dir.join(".cccc.cache").exists(),
+        "--no-cache must not write a cache file"
+    );
+
+    Command::cargo_bin("cccc")
+        .unwrap()
+        .current_dir(&dir)
+        .arg(".")
+        .assert()
+        .success();
+    assert!(
+        dir.join(".cccc.cache").is_file(),
+        "config-enabled cache defaults to .cccc.cache beside the config"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 // ----- JSON formatting -------------------------------------------------------
 
 #[test]


### PR DESCRIPTION
The cache reuses the previous run's per-file scores for files unchanged since then (validated by size/mtime, the analyzing language, and the cccc version), re-analyzing only what changed. Output is byte-for-byte identical to an uncached run; warm runs on large monorepos are ~2.7x (TS/JS via oxc) to ~18x (tree-sitter languages) faster — measured numbers in BENCHMARK.md.

Format: one small index plus concatenated per-entry bincode blobs, so a warm run decodes only the entries it actually hits, in parallel on the same rayon pool that drives analysis (keeping --jobs an honest bound). A corrupt, torn, or version-mismatched cache degrades to a cold run.

Enable with --cache / cache = true; the file defaults to .cccc.cache beside the config file so runs from any subdirectory share it.