### PR TITLE
Prune deleted files' entries from the results cache

### DIFF
--- a/crates/cccc-cli/src/cache.rs
+++ b/crates/cccc-cli/src/cache.rs
@@ -88,6 +88,11 @@ pub fn load(path: &Path) -> Option<Cache> {
 }
 
 impl Cache {
+    /// Number of files this cache holds entries for.
+    pub fn entry_count(&self) -> usize {
+        self.index.len()
+    }
+
     /// The cached report for `path`, if the file still matches its recorded
     /// signature and is still analyzed by `lang`.
     pub fn lookup(&self, path: &Path, lang: &str) -> Option<FileReport> {

--- a/crates/cccc-cli/src/lib.rs
+++ b/crates/cccc-cli/src/lib.rs
@@ -261,10 +261,15 @@ pub fn run() -> i32 {
     };
     reports.extend(cached_reports);
 
-    // Refresh the cache — unless every file was a hit, in which case it is
-    // already exactly what we would write.
+    // Refresh the cache — unless it is already exactly what we would write:
+    // every file was a hit AND the cache holds nothing else. The second check
+    // matters when files were deleted (or newly excluded) since the last run —
+    // all-hits alone would skip the write and leave their stale entries behind.
+    let cache_is_current = cache
+        .as_ref()
+        .is_some_and(|c| to_analyze.is_empty() && c.entry_count() == reports.len());
     if let Some(cache_file) = cache_path.as_deref()
-        && !(cache.is_some() && to_analyze.is_empty())
+        && !cache_is_current
     {
         let store = || {
             cache::store(cache_file, &reports, &|p| {

--- a/crates/cccc-cli/tests/cli.rs
+++ b/crates/cccc-cli/tests/cli.rs
@@ -776,6 +776,48 @@ fn cache_reuses_unchanged_files_and_reanalyzes_edits() {
 }
 
 #[test]
+fn cache_prunes_deleted_files() {
+    let dir = std::env::temp_dir().join("cccc_cache_delete_cli_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("keep.ts"), "function keep() { return 1; }").unwrap();
+    std::fs::write(dir.join("gone.ts"), "function gone() { return 2; }").unwrap();
+    let cache = dir.join("cache.bin");
+
+    let run = || {
+        let out = Command::cargo_bin("cccc")
+            .unwrap()
+            .args(["--no-config", "--cache-file"])
+            .arg(&cache)
+            .arg(&dir)
+            .assert()
+            .success();
+        let v: serde_json::Value =
+            serde_json::from_slice(&out.get_output().stdout).expect("valid JSON");
+        analyzed_names(&v)
+    };
+
+    let mut cold = run();
+    cold.sort();
+    assert_eq!(cold, vec!["gone.ts", "keep.ts"]);
+
+    // Delete one file; nothing else changes, so every surviving file is a
+    // cache hit — the deleted file must vanish from the output anyway.
+    std::fs::remove_file(dir.join("gone.ts")).unwrap();
+    assert_eq!(run(), vec!["keep.ts"], "deleted file must not resurface");
+
+    // And its stale entry must be pruned from the cache file, not left behind
+    // by the "all hits, skip the write" fast path. (Cached paths are stored as
+    // plain strings, so a byte search is a valid containment check.)
+    let bytes = std::fs::read(&cache).unwrap();
+    let needle = b"gone.ts";
+    let contains = bytes.windows(needle.len()).any(|w| w == needle);
+    assert!(!contains, "cache must no longer reference the deleted file");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn no_cache_flag_disables_config_enabled_cache() {
     let dir = std::env::temp_dir().join("cccc_no_cache_cli_test");
     let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
The "every file was a cache hit, skip the write" fast path assumed the cache on disk already matched what a write would produce. That breaks when the only change since the last run is a deletion (or a file newly excluded): the surviving files all hit, the write was skipped, and the removed file's entry lingered in the cache file. Harmless for output — analysis is discovery-driven, so a deleted file can never resurface — but stale data all the same.

Skip the write only when the hit count also equals the cache's entry count; since an all-hit run's hits are a subset of the index, equal sizes mean the sets are identical. A mismatch rewrites the cache and prunes the dead entries.