### PR TITLE
Validate cache entries by content and git's index — the cache now works in CI

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -157,10 +157,12 @@ verify-then-time script). Build cccc with `cargo build --release`; install scc
 
 # Benchmark: the results cache (`--cache`)
 
-The results cache reuses the previous run's per-file scores for files whose
-size/mtime are unchanged (still validated per entry against the analyzing
-language and the cccc version), re-analyzing only what changed. These numbers
-size what that buys on real monorepos, per language front-end.
+The results cache reuses the previous run's per-file scores for unchanged
+files (still validated per entry against the analyzing language and the cccc
+version), re-analyzing only what changed. As first shipped, "unchanged" meant
+size/mtime alone; the update at the end of this file reworks validation to
+survive mtime churn (a fresh CI checkout, a branch switch). These numbers
+size what the cache buys on real monorepos, per language front-end.
 
 ## Corpora
 
@@ -230,4 +232,83 @@ target/release/cccc --no-config /tmp/k8s > /dev/null
 # populate, then warm
 target/release/cccc --no-config --cache-file /tmp/k8s.cache /tmp/k8s > /dev/null
 target/release/cccc --no-config --cache-file /tmp/k8s.cache /tmp/k8s > /dev/null
+```
+
+## Update (2026-07-19): validation reworked — stat, then git's index, then the blob SHA
+
+The size/mtime check above has a blind spot: anything that rewrites mtimes
+without changing content. The big one is CI — `git clone`/`actions/checkout`
+stamp every file with the checkout time, so a cache restored by
+`actions/cache` would never hit. Measured with every mtime bumped but no
+content changed, the mtime-only cache was **worse than no cache at all**: it
+re-analyzed everything *and* rewrote the whole cache file — vscode 127.5 ms
+vs 107.8 ms cold, postgres 576.6 ms vs 544.5 ms cold.
+
+Validation is now a cheapest-first chain (details in the README and
+`cache.rs`). Each entry stores size, mtime, and the SHA-1 git would name a
+blob of the content — computed by cccc from the bytes it analyzed, never
+taken on faith from git, so every check is content-to-content and it never
+matters which commit (or how stale a run) a restored cache came from:
+
+1. **stat** — size+mtime match: trusted with no read (the local fast path).
+2. **git's index** — mtime moved but git calls the file clean and the
+   index's blob SHA matches the stored one: still no read. One
+   `git ls-files -s`/`git status` pair answers for the whole tree. git is
+   consulted lazily, only after some stat check failed — an all-stat-hit
+   run doesn't even spawn it (an eager-spawn draft cost 15–30 ms of `git
+   status` contention on big trees) — except under `CI=…`, where it starts
+   ahead of file discovery to hide its latency.
+3. **blob SHA re-derived from the bytes** — the final authority, for
+   whatever git can't vouch: dirty/untracked files, non-git trees, filtered
+   (e.g. CRLF-normalized) files, any git failure at all.
+
+A hit via 2 or 3 persists the refreshed mtime, so churn converges to stat
+hits after one run. On the choice of hash: candidates were benchmarked at
+~48 GB/s (xxh3-128), ~12 GB/s (hw CRC32), and ~1.3 GB/s (SHA-1), but the
+re-derive path is I/O-bound — ~0.6–1.5 GB/s effective including opens — so
+even the slowest never reaches the wall clock, and the SHA-1 git already
+requires is the only candidate that also serves the index check. One
+content identity, one hash dependency (`sha1_smol`).
+
+### Results
+
+Corpora as above, except vscode: fixing this machine's partial LFS checkout
+grew that tree to its true size, **12,301 analyzed files** (earlier sections
+measured the 2,976-file subset; their numbers remain internally consistent).
+Same machine and method (median of 5 after 1 warmup, stdout to `/dev/null`).
+"CI churn" bumps every mtime and re-syncs git's stat cache before each run —
+the state `actions/checkout` leaves — with `CI=true`; "hash only" is the
+same churn with git made unavailable; "local churn" is a branch-switch-like
+state without `CI` (git started on demand):
+
+| Corpus | cold | warm (stat) | CI churn, git | CI churn, hash only | local churn, git |
+|--------|-----:|------------:|--------------:|--------------------:|-----------------:|
+| vscode (TS/JS, 12,301) | 345.0 | 149.1 | **225.3** | 399.9 | 259.6 |
+| kubernetes (Go, 17,518) | 992.7 | 181.7 | **307.2** | 651.6 | 364.2 |
+| postgres (C, 2,954) | 525.3 | 33.6 | **56.2** | 92.9 | 75.0 |
+
+Reading it:
+
+- **CI goes from net-negative to a real win**: 1.5× (vscode — oxc parses
+  nearly as fast as re-validating), 3.2× (kubernetes), 9.3× (postgres)
+  faster than cold, and 1.7–2.1× faster than re-hashing the tree.
+- **A fully warm local run pays exactly nothing for any of it**: stat hits
+  never read a file and never consult (or spawn) git — warm medians measure
+  equal with git present or absent.
+- **Local mtime churn benefits too**: a branch switch validates off git on
+  demand and still beats re-hashing the tree.
+- Outputs stay byte-for-byte identical to cold runs in every scenario
+  (verified on all three corpora before timing), and churn converges: the
+  run after the rewrite is back to pure stat hits with no cache write.
+
+### Reproduce
+
+```sh
+cargo build --release
+git clone --depth 1 https://github.com/kubernetes/kubernetes /tmp/k8s
+target/release/cccc --no-config --cache-file /tmp/k8s.cache /tmp/k8s > /dev/null  # populate
+# Emulate a fresh CI checkout: bump every mtime, re-sync git's stat cache.
+find /tmp/k8s -type f -not -path '*/.git/*' -print0 | xargs -0 touch
+git -C /tmp/k8s update-index --refresh -q
+CI=true target/release/cccc --no-config --cache-file /tmp/k8s.cache /tmp/k8s > /dev/null
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "sha1_smol",
  "toml",
 ]
 
@@ -1374,6 +1375,12 @@ checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "shlex"

--- a/README.md
+++ b/README.md
@@ -210,20 +210,67 @@ directory or named explicitly on the command line. An invalid pattern is an erro
 
 ### Results cache
 
-For continuous measurement — watch loops, pre-commit hooks, editor
-integrations — `--cache` (or `cache = true` in `cccc.toml`) makes repeat runs
-reuse the previous results for files that haven't changed, re-analyzing only
-what did. On large monorepos this cuts warm runs by ~2.7× (TS/JS) to ~18×
-(tree-sitter languages such as C) — measured numbers are in
-[BENCHMARK.md](BENCHMARK.md) — and the output is byte-for-byte identical to an
-uncached run.
+`--cache` (or `cache = true` in `cccc.toml`) makes repeat runs reuse the
+previous results for files that haven't changed, re-analyzing only what did.
+The output is byte-for-byte identical to an uncached run: the cache is an
+accelerator, never a source of errors — anything unexpected (a missing,
+corrupt, or version-mismatched cache file) just degrades to a full run. It
+pays off wherever cccc runs repeatedly over a mostly-unchanged tree: watch
+loops, pre-commit hooks, editor integrations, and CI. On large monorepos,
+warm runs measure ~3× (TS/JS via oxc) to ~17× (tree-sitter languages such as
+C) faster than cold ones — numbers and method in
+[BENCHMARK.md](BENCHMARK.md).
 
-An entry is reused only if the file's size and mtime are unchanged, the same
-language still claims its extension, and the cache was written by the same
-`cccc` version — anything else (including a missing or corrupt cache file) just
-means that file is analyzed fresh. The cache lives in `.cccc.cache` next to the
-config file (so runs from any subdirectory share it), or where `--cache-file`
-points; add it to `.gitignore`.
+An entry is reused only when it provably still describes the file's current
+content, checked cheapest-first:
+
+1. **stat** — size and mtime unchanged: trusted without reading the file.
+   The steady local path; a fully warm run does nothing but stat.
+2. **git's index** — the mtime moved, but git calls the file clean and the
+   index's blob SHA matches the one recorded at analysis time: still no
+   read. One `git ls-files`/`git status` pair answers for the whole tree,
+   which is what keeps fresh CI checkouts (every mtime reset) warm. git is
+   consulted only after a stat check has failed, and never trusted beyond
+   content: dirty or untracked files, non-git trees, and any git failure at
+   all fall through to step 3.
+3. **content re-hash** — the file is read and its blob SHA re-derived from
+   the bytes; the final authority, and the same value step 2 compares
+   without reading. A mismatch means the content really changed, and only
+   then is the file re-analyzed. (The blob SHA is SHA-1 — the same
+   non-adversarial, per-path content comparison git itself rests on, not a
+   cryptographic boundary.)
+
+A hit that needed step 2 or 3 gets its refreshed mtime written back, so the
+next run takes the stat path again. Entries are also keyed to the analyzing
+language (`--ext` re-routing must not resurface another language's scores),
+and the whole cache to the cccc version that wrote it.
+
+The cache lives in `.cccc.cache` next to the config file (so runs from any
+subdirectory share it), or where `--cache-file` points; add it to
+`.gitignore`. It needs no maintenance beyond that: every run rewrites it to
+match exactly the current tree — deleted files' entries are pruned, and its
+size stays proportional to the project, not its history — and deleting the
+file at any time is always safe (the next run is simply cold).
+
+#### In CI
+
+The git-index check is what makes the cache effective in CI, where every
+checkout resets every mtime: persist the cache file across runs and each run
+validates unchanged files off git's index instead of re-parsing them —
+measured 1.6–9.6× faster than a cold run (see BENCHMARK.md). Correctness
+never depends on which commit (or how stale a run) the restored cache came
+from: every entry is checked content-to-content. Under `CI=…` (GitHub
+Actions sets it) the git subprocesses start early so their latency hides
+behind file discovery. For example:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: .cccc.cache
+    key: cccc-${{ github.sha }}
+    restore-keys: cccc-
+- run: cccc --cache --max-cognitive 15 src/
+```
 
 ### Examples
 

--- a/crates/cccc-cli/Cargo.toml
+++ b/crates/cccc-cli/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1"
 bincode = "1"
 toml = "1.1"
 rayon = "1"
+sha1_smol = "1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/cccc-cli/src/cache.rs
+++ b/crates/cccc-cli/src/cache.rs
@@ -2,11 +2,21 @@
 //!
 //! Analysis is a pure function of a file's content and the language front-end
 //! that handles it, so a cached [`FileReport`] can be reused as long as neither
-//! changed. An entry is validated by (size, mtime) — stat-level checks, no file
-//! read — plus the canonical name of the language that produced it (extension
-//! re-routing via `--ext`/`[ext]` must not resurface another language's scores).
-//! The whole cache is stamped with the cccc version, since counting rules can
-//! change between releases.
+//! changed. Validation is hybrid, the way git's index does it: an entry stores
+//! the file's size, mtime, and the SHA-1 git would name a blob of its content.
+//! When size and mtime both match, the entry is trusted on the stat alone — no
+//! file read. When the mtime moved but the size didn't, that one content
+//! identity is checked by whichever route is cheapest: in a git worktree, a
+//! churned file that git's own index calls clean is validated against the
+//! index's blob SHA without reading it (see [`GitIndex`]); otherwise the file
+//! is read and its blob SHA re-derived. Either way a match is still a hit (the
+//! content is what was analyzed), and the entry's mtime is refreshed so the
+//! next run stat-hits again. This keeps warm local runs at stat speed while
+//! surviving mtime churn — a fresh `git clone` in CI, a branch switch, a
+//! `touch`. Each entry also records the canonical name of the language that
+//! produced it (extension re-routing via `--ext`/`[ext]` must not resurface
+//! another language's scores), and the whole cache is stamped with the cccc
+//! version, since counting rules can change between releases.
 //!
 //! ## File layout
 //!
@@ -25,7 +35,8 @@
 //! skipped field shifts every later byte of the stream).
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
 
 use rayon::prelude::*;
 
@@ -34,13 +45,224 @@ use cccc_core::report::{FileReport, FunctionReport};
 /// Entries are only valid for the exact version that wrote them.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Validation signature for one file: stat facts for the cheap check, and
+/// the content's git blob SHA as ground truth when the mtime has moved. One
+/// content identity serves both slow paths: the git index compares it
+/// without reading the file (see [`git_index`]), the fallback re-derives it
+/// from the bytes.
+#[derive(Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Sig {
+    size: u64,
+    mtime_ns: u128,
+    blob_sha: [u8; 20],
+}
+
+/// The signature of content `bytes` observed at `mtime_ns`.
+pub fn sig_for(bytes: &[u8], mtime_ns: u128) -> Sig {
+    Sig {
+        size: bytes.len() as u64,
+        mtime_ns,
+        blob_sha: git_blob_sha1(bytes),
+    }
+}
+
+/// The SHA-1 git would name a blob holding `bytes` — computed here from the
+/// bytes themselves, so a stored signature never depends on git having been
+/// right about a file at store time.
+fn git_blob_sha1(bytes: &[u8]) -> [u8; 20] {
+    let mut h = sha1_smol::Sha1::new();
+    h.update(format!("blob {}\0", bytes.len()).as_bytes());
+    h.update(bytes);
+    h.digest().bytes()
+}
+
+/// Blob SHAs of the clean tracked files under one git worktree: what each
+/// file's content is, answered from git's own index without reading the file.
+///
+/// A fresh CI checkout resets every mtime, which would push the whole tree
+/// onto the content-hash fallback. But that checkout also wrote git's index,
+/// which already names each file's blob — and `git status` confirms, by stat,
+/// which files still match it. A lookup whose stat check failed on the mtime
+/// alone and whose stored blob SHA matches the index's is a hit without
+/// reading the file.
+///
+/// Trust runs content-to-content: stored SHAs are computed by cccc from the
+/// analyzed bytes (see [`sig_for`]), and the index vouches for the checked-out
+/// bytes, so a match never assumes the cache and the checkout describe the
+/// same commit. Files git reports dirty are dropped from the map, and any git
+/// failure — no repository, no git binary, a SHA-256 repository — yields
+/// `None`; both just fall back to stat/hash validation.
+pub struct GitIndex {
+    shas: HashMap<PathBuf, [u8; 20]>,
+}
+
+impl GitIndex {
+    /// The index's blob SHA for `path`, if it is a clean tracked file.
+    fn sha_of(&self, path: &Path) -> Option<[u8; 20]> {
+        self.shas.get(&std::path::absolute(path).ok()?).copied()
+    }
+}
+
+/// A [`GitIndex`] materialized only if a lookup actually needs it.
+/// Stat-validated hits never consult git, so a fully warm local run pays
+/// nothing — not even the subprocesses, whose `git status` is a stat pass
+/// over the whole tree that would contend with our own.
+///
+/// Under `CI=…` (every major CI service sets it) the subprocesses instead
+/// start eagerly on a background thread: there the checkout has reset every
+/// mtime, git is needed with near-certainty, and starting it before file
+/// discovery hides its latency entirely. Either way, the first lookup that
+/// sees a moved mtime waits for the answer — its alternative was reading and
+/// hashing the file, strictly more work than the wait once amortized over
+/// every churned file.
+pub struct LazyGitIndex {
+    index: std::sync::OnceLock<Option<GitIndex>>,
+    source: std::sync::Mutex<Option<GitIndexSource>>,
+}
+
+enum GitIndexSource {
+    /// Not started; the worktree root to read if anyone asks.
+    Pending(PathBuf),
+    /// Already reading on a background thread (the CI path).
+    Running(std::thread::JoinHandle<Option<GitIndex>>),
+}
+
+impl LazyGitIndex {
+    /// Prepare to read the git index of the worktree containing `root`.
+    pub fn new(root: PathBuf) -> Self {
+        let source = if std::env::var("CI").is_ok_and(|v| !v.is_empty() && v != "false") {
+            GitIndexSource::Running(std::thread::spawn(move || git_index(&root)))
+        } else {
+            GitIndexSource::Pending(root)
+        };
+        Self {
+            index: std::sync::OnceLock::new(),
+            source: std::sync::Mutex::new(Some(source)),
+        }
+    }
+
+    fn get(&self) -> Option<&GitIndex> {
+        self.index
+            .get_or_init(
+                || match self.source.lock().ok().and_then(|mut s| s.take())? {
+                    GitIndexSource::Pending(root) => git_index(&root),
+                    GitIndexSource::Running(handle) => handle.join().ok().flatten(),
+                },
+            )
+            .as_ref()
+    }
+}
+
+impl Drop for LazyGitIndex {
+    /// Reap an eagerly-started thread nobody awaited. Letting it run into
+    /// process exit is observable: under coverage instrumentation the
+    /// profile dump races the thread's counter updates, producing corrupt
+    /// (negative) counts that break LCOV consumers.
+    fn drop(&mut self) {
+        if let Ok(mut source) = self.source.lock()
+            && let Some(GitIndexSource::Running(handle)) = source.take()
+        {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Read the git index of the worktree containing `root`.
+pub fn git_index(root: &Path) -> Option<GitIndex> {
+    let toplevel = PathBuf::from(git(root, &["rev-parse", "--show-toplevel"])?.trim_end());
+    // `ls-files -s`: "<mode> <sha> <stage>\t<path>", NUL-terminated. Keep
+    // regular blobs at stage 0: gitlinks and symlinks aren't analyzable files,
+    // a nonzero stage is an unmerged path, and a SHA that isn't 40 hex digits
+    // means a SHA-256 repository, whose blob names can never match ours.
+    let mut shas = HashMap::new();
+    for entry in git(root, &["ls-files", "-s", "-z"])?
+        .split('\0')
+        .filter(|e| !e.is_empty())
+    {
+        let Some((meta, path)) = entry.split_once('\t') else {
+            continue;
+        };
+        let mut fields = meta.split(' ');
+        let (Some(mode), Some(sha), Some("0")) = (fields.next(), fields.next(), fields.next())
+        else {
+            continue;
+        };
+        if !mode.starts_with("100") {
+            continue;
+        }
+        let Some(sha) = decode_sha1(sha) else {
+            continue;
+        };
+        shas.insert(toplevel.join(path), sha);
+    }
+    // `status --porcelain -z`: "XY <path>", NUL-terminated. Anything listed is
+    // not clean; whatever the reason, its index SHA can't be trusted.
+    for entry in git(
+        root,
+        &["status", "--porcelain", "-z", "-uno", "--no-renames"],
+    )?
+    .split('\0')
+    .filter(|e| !e.is_empty())
+    {
+        let Some(path) = entry.get(3..) else { continue };
+        shas.remove(&toplevel.join(path));
+    }
+    Some(GitIndex { shas })
+}
+
+/// Run git in `dir` and return its stdout, `None` on any failure.
+fn git(dir: &Path, args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout).ok()
+}
+
+fn decode_sha1(hex: &str) -> Option<[u8; 20]> {
+    let hex = hex.as_bytes();
+    if hex.len() != 40 {
+        return None;
+    }
+    let mut out = [0u8; 20];
+    for (i, b) in out.iter_mut().enumerate() {
+        let hi = (hex[2 * i] as char).to_digit(16)?;
+        let lo = (hex[2 * i + 1] as char).to_digit(16)?;
+        *b = (hi * 16 + lo) as u8;
+    }
+    Some(out)
+}
+
+/// The mtime of `path` in nanoseconds since the epoch. Callers that go on to
+/// read the file should stat first: if the file changes in between, the stored
+/// mtime is then older than the analyzed content, and the staleness is caught
+/// by the next run's hash check instead of masking the newer content.
+pub fn mtime_ns(path: &Path) -> Option<u128> {
+    mtime_of(&std::fs::metadata(path).ok()?)
+}
+
+fn mtime_of(md: &std::fs::Metadata) -> Option<u128> {
+    Some(
+        md.modified()
+            .ok()?
+            .duration_since(UNIX_EPOCH)
+            .ok()?
+            .as_nanos(),
+    )
+}
+
 /// Validation signature plus blob location for one cached file.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct IndexEntry {
     /// Canonical name of the language that analyzed the file.
     lang: String,
-    size: u64,
-    mtime_ns: u128,
+    sig: Sig,
     offset: u64,
     len: u64,
 }
@@ -64,6 +286,16 @@ struct CacheReport {
     cyclomatic: u32,
     functions: Vec<CacheFun>,
     parse_errors: Vec<String>,
+}
+
+/// A cache hit: the reusable report and the file's current signature.
+/// `refreshed` marks a hit that went through the content check — the stored
+/// mtime is stale, so the cache file should be rewritten with `sig` to make
+/// the next run stat-hit instead of hashing again.
+pub struct Hit {
+    pub report: FileReport,
+    pub sig: Sig,
+    pub refreshed: bool,
 }
 
 /// A loaded cache: the lookup index plus the raw, still-encoded entry blobs.
@@ -94,12 +326,50 @@ impl Cache {
     }
 
     /// The cached report for `path`, if the file still matches its recorded
-    /// signature and is still analyzed by `lang`.
-    pub fn lookup(&self, path: &Path, lang: &str) -> Option<FileReport> {
+    /// signature — by stat, by git's index, or by re-hashing the content
+    /// when only the mtime moved — and is still analyzed by `lang`.
+    pub fn lookup(&self, path: &Path, lang: &str, git: Option<&LazyGitIndex>) -> Option<Hit> {
         let entry = self.index.get(&path.display().to_string())?;
-        if entry.lang != lang || file_sig(path)? != (entry.size, entry.mtime_ns) {
+        if entry.lang != lang {
             return None;
         }
+        let md = std::fs::metadata(path).ok()?;
+        if md.len() != entry.sig.size {
+            return None;
+        }
+        let mtime = mtime_of(&md)?;
+        let sig = if mtime == entry.sig.mtime_ns {
+            entry.sig
+        } else if git.and_then(|g| g.get()).and_then(|g| g.sha_of(path)) == Some(entry.sig.blob_sha)
+        {
+            // The mtime moved but git's index vouches that the file still
+            // holds the very blob we analyzed — no read needed. (Only now is
+            // the git subprocess awaited: an all-stat-hit run never blocks
+            // on it.)
+            Sig {
+                mtime_ns: mtime,
+                ..entry.sig
+            }
+        } else {
+            // The mtime moved (checkout, touch, rewrite-in-place) and git has
+            // nothing to say; re-derive the blob SHA from the bytes. Size is
+            // re-checked from those bytes too, in case the file changed again
+            // between the stat and the read.
+            let sig = sig_for(&std::fs::read(path).ok()?, mtime);
+            if sig.size != entry.sig.size || sig.blob_sha != entry.sig.blob_sha {
+                return None;
+            }
+            sig
+        };
+        Some(Hit {
+            report: self.decode(entry)?,
+            refreshed: sig.mtime_ns != entry.sig.mtime_ns,
+            sig,
+        })
+    }
+
+    /// Decode `entry`'s blob into its report.
+    fn decode(&self, entry: &IndexEntry) -> Option<FileReport> {
         let blob = self
             .blobs
             .get(entry.offset as usize..(entry.offset + entry.len) as usize)?;
@@ -108,27 +378,27 @@ impl Cache {
     }
 }
 
-/// Write a fresh cache for `reports` to `path`, replacing any previous file.
-/// `lang_for` names the language that analyzed a path (entries it can't name
-/// are simply not cached). Encoding fans out on the current rayon pool; a
-/// failed write only costs the next run its warm start, so it warns rather
-/// than failing the process.
+/// Write a fresh cache for `entries` to `path`, replacing any previous file.
+/// Signatures come from the caller — hashed from bytes it already had in
+/// memory, never by re-reading here — and an entry without one (its read-time
+/// stat failed), or whose language `lang_for` can't name, is simply not
+/// cached. Encoding fans out on the current rayon pool; a failed write only
+/// costs the next run its warm start, so it warns rather than failing the
+/// process.
 pub fn store(
     path: &Path,
-    reports: &[FileReport],
+    entries: &[(FileReport, Option<Sig>)],
     lang_for: &(dyn Fn(&Path) -> Option<&'static str> + Sync),
 ) {
-    let encoded: Vec<(String, IndexEntry, Vec<u8>)> = reports
+    let encoded: Vec<(String, IndexEntry, Vec<u8>)> = entries
         .par_iter()
-        .filter_map(|r| {
-            let file = Path::new(&r.path);
-            let lang = lang_for(file)?;
-            let (size, mtime_ns) = file_sig(file)?;
+        .filter_map(|(r, sig)| {
+            let sig = (*sig)?;
+            let lang = lang_for(Path::new(&r.path))?;
             let blob = bincode::serialize(&to_cache(r)).ok()?;
             let entry = IndexEntry {
                 lang: lang.to_string(),
-                size,
-                mtime_ns,
+                sig,
                 offset: 0, // fixed up below, once concatenation order is known
                 len: blob.len() as u64,
             };
@@ -158,18 +428,6 @@ pub fn store(
             path.display()
         ));
     }
-}
-
-/// Stat `path` into its cache-validation signature.
-fn file_sig(path: &Path) -> Option<(u64, u128)> {
-    let md = std::fs::metadata(path).ok()?;
-    let mtime = md
-        .modified()
-        .ok()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?
-        .as_nanos();
-    Some((md.len(), mtime))
 }
 
 fn to_cache_funs(fns: &[FunctionReport]) -> Vec<CacheFun> {
@@ -246,6 +504,16 @@ mod tests {
         }
     }
 
+    /// Store a one-entry cache for `src`, signed off its current content.
+    fn store_one(cache_file: &Path, src: &Path, lang: &'static str) {
+        let sig = sig_for(&std::fs::read(src).unwrap(), mtime_ns(src).unwrap());
+        store(
+            cache_file,
+            &[(sample_report(&src.display().to_string()), Some(sig))],
+            &move |_| Some(lang),
+        );
+    }
+
     #[test]
     fn roundtrip_hits_for_unchanged_file() {
         let dir = std::env::temp_dir().join("cccc_cache_unit_roundtrip");
@@ -254,14 +522,14 @@ mod tests {
         std::fs::write(&src, "function f() {}").unwrap();
         let cache_file = dir.join("cache.bin");
 
-        let report = sample_report(&src.display().to_string());
-        store(&cache_file, &[report], &|_| Some("es"));
+        store_one(&cache_file, &src, "es");
 
         let cache = load(&cache_file).expect("cache loads");
-        let hit = cache.lookup(&src, "es").expect("unchanged file hits");
-        assert_eq!(hit.cognitive, 3);
-        assert_eq!(hit.functions[0].children[0].name, "g");
-        assert_eq!(hit.parse_errors, vec!["boom".to_string()]);
+        let hit = cache.lookup(&src, "es", None).expect("unchanged file hits");
+        assert!(!hit.refreshed, "a stat hit needs no rewrite");
+        assert_eq!(hit.report.cognitive, 3);
+        assert_eq!(hit.report.functions[0].children[0].name, "g");
+        assert_eq!(hit.report.parse_errors, vec!["boom".to_string()]);
 
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -271,22 +539,280 @@ mod tests {
         let dir = std::env::temp_dir().join("cccc_cache_unit_invalidate");
         std::fs::create_dir_all(&dir).unwrap();
         let src = dir.join("a.ts");
-        std::fs::write(&src, "function f() {}").unwrap();
+        std::fs::write(&src, "function f() { return 1 }").unwrap();
         let cache_file = dir.join("cache.bin");
 
-        store(
-            &cache_file,
-            &[sample_report(&src.display().to_string())],
-            &|_| Some("es"),
-        );
+        store_one(&cache_file, &src, "es");
         let cache = load(&cache_file).unwrap();
         assert!(
-            cache.lookup(&src, "rust").is_none(),
+            cache.lookup(&src, "rust", None).is_none(),
             "other language misses"
         );
 
-        std::fs::write(&src, "function f() { return 1 }").unwrap();
-        assert!(cache.lookup(&src, "es").is_none(), "changed file misses");
+        // Same size, different content: the stat check passes on size, the
+        // hash check must still reject it.
+        std::fs::write(&src, "function f() { return 2 }").unwrap();
+        assert!(
+            cache.lookup(&src, "es", None).is_none(),
+            "same-size edit misses via hash"
+        );
+
+        std::fs::write(&src, "function f() {}").unwrap();
+        assert!(
+            cache.lookup(&src, "es", None).is_none(),
+            "resized file misses"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mtime_only_change_hits_via_hash_and_refreshes() {
+        let dir = std::env::temp_dir().join("cccc_cache_unit_touch");
+        std::fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("a.ts");
+        std::fs::write(&src, "function f() {}").unwrap();
+        let cache_file = dir.join("cache.bin");
+
+        store_one(&cache_file, &src, "es");
+
+        // Same bytes, new mtime — what a fresh git checkout does to every file.
+        let bumped = std::time::SystemTime::now() + std::time::Duration::from_secs(10);
+        std::fs::File::options()
+            .write(true)
+            .open(&src)
+            .unwrap()
+            .set_modified(bumped)
+            .unwrap();
+
+        let cache = load(&cache_file).unwrap();
+        let hit = cache.lookup(&src, "es", None).expect("content match hits");
+        assert!(hit.refreshed, "a hash hit asks for a rewrite");
+        assert_eq!(hit.report.cognitive, 3);
+
+        // Re-storing with the refreshed signature turns it back into a stat hit.
+        store(&cache_file, &[(hit.report, Some(hit.sig))], &|_| Some("es"));
+        let hit = load(&cache_file).unwrap().lookup(&src, "es", None).unwrap();
+        assert!(!hit.refreshed, "refreshed mtime now stat-hits");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn git_blob_sha1_matches_git() {
+        // `git hash-object` of an empty file and of "hello\n".
+        let hex = |sha: [u8; 20]| sha.iter().map(|b| format!("{b:02x}")).collect::<String>();
+        assert_eq!(
+            hex(git_blob_sha1(b"")),
+            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+        );
+        assert_eq!(
+            hex(git_blob_sha1(b"hello\n")),
+            "ce013625030ba8dba906f756967f9e9ca394464a"
+        );
+    }
+
+    #[test]
+    fn git_blob_sha1_agrees_with_git_hash_object() {
+        // Differential check against the installed git, over content shapes
+        // the fixed vectors above don't cover: multibyte UTF-8, CRLF, NUL
+        // bytes, and a multi-KB buffer (exercises sha1 block handling).
+        let git_hash_object = |bytes: &[u8]| -> String {
+            use std::io::Write;
+            let mut child = std::process::Command::new("git")
+                .args(["hash-object", "--stdin"])
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped())
+                .spawn()
+                .unwrap();
+            child.stdin.take().unwrap().write_all(bytes).unwrap();
+            let out = child.wait_with_output().unwrap();
+            assert!(out.status.success(), "git hash-object failed");
+            String::from_utf8(out.stdout)
+                .unwrap()
+                .trim_end()
+                .to_string()
+        };
+        let hex = |sha: [u8; 20]| sha.iter().map(|b| format!("{b:02x}")).collect::<String>();
+
+        let mut big = Vec::with_capacity(8192);
+        for i in 0..8192u32 {
+            big.push((i.wrapping_mul(2654435761) >> 24) as u8);
+        }
+        let contents: Vec<&[u8]> = vec![
+            b"",
+            b"x",
+            "関数の複雑度 → スコア\n".as_bytes(),
+            b"line one\r\nline two\r\n",
+            b"nul\x00in the middle",
+            &big,
+        ];
+        for bytes in contents {
+            assert_eq!(
+                hex(git_blob_sha1(bytes)),
+                git_hash_object(bytes),
+                "blob SHA must match git's for {} bytes",
+                bytes.len()
+            );
+        }
+    }
+
+    #[test]
+    fn git_index_vouches_for_clean_files_only() {
+        let dir = std::env::temp_dir().join("cccc_cache_unit_gitindex");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // `git rev-parse --show-toplevel` resolves symlinks (macOS /tmp);
+        // canonicalize so our paths agree with git's.
+        let dir = dir.canonicalize().unwrap();
+        let src = dir.join("a.ts");
+        std::fs::write(&src, "function f() {}").unwrap();
+        let run_git = |args: &[&str]| {
+            assert!(
+                std::process::Command::new("git")
+                    .arg("-C")
+                    .arg(&dir)
+                    .args(args)
+                    .output()
+                    .unwrap()
+                    .status
+                    .success()
+            );
+        };
+        run_git(&["init", "-q"]);
+        run_git(&["add", "."]);
+        run_git(&[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "-q",
+            "-m",
+            "x",
+        ]);
+
+        let cache_file = dir.join("cache.bin");
+        store_one(&cache_file, &src, "es");
+        let cache = load(&cache_file).unwrap();
+
+        // An mtime-only change: the git index vouches without reading the
+        // file. Dropping read permission proves the hit really came from git —
+        // the content-hash fallback would need to open the file. The mtime
+        // moves into the past: a future mtime would trip git's racy-clean
+        // check, which re-reads the file on every status.
+        let bumped = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        std::fs::File::options()
+            .write(true)
+            .open(&src)
+            .unwrap()
+            .set_modified(bumped)
+            .unwrap();
+        // Re-sync the index's stat cache (as a checkout would have), so `git
+        // status` can call the file clean without re-reading it.
+        run_git(&["update-index", "--refresh"]);
+        #[cfg(unix)]
+        let perms = {
+            use std::os::unix::fs::PermissionsExt;
+            let orig = std::fs::metadata(&src).unwrap().permissions();
+            std::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o000)).unwrap();
+            orig
+        };
+        let git = LazyGitIndex::new(dir.clone());
+        let hit = cache
+            .lookup(&src, "es", Some(&git))
+            .expect("clean file hits via git");
+        assert!(hit.refreshed, "a git hit persists the fresh mtime");
+        assert_eq!(hit.report.cognitive, 3);
+        #[cfg(unix)]
+        std::fs::set_permissions(&src, perms).unwrap();
+
+        // A dirty file drops out of the map and must fail validation (the
+        // content changed, so the stat/hash fallback rejects it too).
+        std::fs::write(&src, "function f() { return 9 }").unwrap();
+        let git = LazyGitIndex::new(dir.clone());
+        assert!(
+            cache.lookup(&src, "es", Some(&git)).is_none(),
+            "dirty file must not hit via the stale index SHA"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A file whose git blob differs from its worktree bytes (a `text`
+    /// attribute normalizes CRLF away on add) must never be vouched for by
+    /// the index: our signature hashes the raw bytes we analyzed, git's index
+    /// names the filtered blob, and the SHAs must disagree. Read permission
+    /// is dropped so the content-hash fallback can't mask a wrong git hit —
+    /// a lookup that succeeded here could only have come from the index.
+    #[cfg(unix)]
+    #[test]
+    fn filtered_file_is_never_vouched_by_the_index() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join("cccc_cache_unit_gitfilter");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let dir = dir.canonicalize().unwrap();
+        let src = dir.join("a.ts");
+        std::fs::write(&src, "function f() {\r\n}\r\n").unwrap();
+        std::fs::write(dir.join(".gitattributes"), "*.ts text\n").unwrap();
+        let run_git = |args: &[&str]| {
+            assert!(
+                std::process::Command::new("git")
+                    .arg("-C")
+                    .arg(&dir)
+                    .args(["-c", "core.autocrlf=false"])
+                    .args(args)
+                    .output()
+                    .unwrap()
+                    .status
+                    .success()
+            );
+        };
+        run_git(&["init", "-q"]);
+        run_git(&["add", "."]);
+        run_git(&[
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "-q",
+            "-m",
+            "x",
+        ]);
+
+        let cache_file = dir.join("cache.bin");
+        store_one(&cache_file, &src, "es");
+        let cache = load(&cache_file).unwrap();
+
+        // The CI shape: mtime moved, content untouched, index stat-clean.
+        let bumped = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        std::fs::File::options()
+            .write(true)
+            .open(&src)
+            .unwrap()
+            .set_modified(bumped)
+            .unwrap();
+        run_git(&["update-index", "--refresh"]);
+        let perms = std::fs::metadata(&src).unwrap().permissions();
+        std::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let git = LazyGitIndex::new(dir.clone());
+        assert!(
+            cache.lookup(&src, "es", Some(&git)).is_none(),
+            "the index's normalized blob SHA must not validate raw CRLF bytes"
+        );
+
+        // Positive control: with the file readable again, the content-hash
+        // fallback rescues the hit — filtered files are slower, never wrong.
+        std::fs::set_permissions(&src, perms).unwrap();
+        let git = LazyGitIndex::new(dir.clone());
+        let hit = cache
+            .lookup(&src, "es", Some(&git))
+            .expect("hash fallback still hits");
+        assert!(hit.refreshed);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/cccc-cli/src/lib.rs
+++ b/crates/cccc-cli/src/lib.rs
@@ -195,6 +195,25 @@ pub fn run() -> i32 {
             .unwrap_or(1)
     });
 
+    // Let cache validation ask git which files are clean and what their blob
+    // SHAs are, so it can skip reading files whose mtime moved but whose
+    // content didn't — the CI fast path: a fresh checkout resets every mtime
+    // but writes a stat-clean index. Consulted (and under CI, started) only
+    // when needed — see [`cache::LazyGitIndex`] — and only prepared at all
+    // when there is an existing cache to validate against.
+    let git_index = cache_path.as_ref().filter(|p| p.exists()).map(|_| {
+        let root = match cli.paths.first() {
+            Some(p) if p.is_dir() => p.clone(),
+            Some(p) => p
+                .parent()
+                .filter(|d| !d.as_os_str().is_empty())
+                .unwrap_or(Path::new("."))
+                .to_path_buf(),
+            None => std::path::PathBuf::from("."),
+        };
+        cache::LazyGitIndex::new(root)
+    });
+
     let files = walk::collect_files(&cli.paths, &exts, no_ignore, exclude.as_ref(), jobs);
     if files.is_empty() {
         eprintln!("cccc: no matching files found");
@@ -220,25 +239,33 @@ pub fn run() -> i32 {
     // Split the files into cache hits (report ready) and misses (to analyze).
     // Without a usable cache everything is a miss.
     let cache = cache_path.as_deref().and_then(cache::load);
-    let (cached_reports, to_analyze): (Vec<FileReport>, Vec<&std::path::PathBuf>) = match &cache {
+    let mut sig_refreshed = false;
+    let (cached_entries, to_analyze): (
+        Vec<(FileReport, Option<cache::Sig>)>,
+        Vec<&std::path::PathBuf>,
+    ) = match &cache {
         Some(c) => {
-            let checked: Vec<Result<FileReport, &std::path::PathBuf>> = match &pool {
+            let git = git_index.as_ref();
+            let checked: Vec<Result<cache::Hit, &std::path::PathBuf>> = match &pool {
                 Some(pool) => pool.install(|| {
                     files
                         .par_iter()
-                        .map(|p| check_cached(c, &dispatch, p))
+                        .map(|p| check_cached(c, &dispatch, p, git))
                         .collect()
                 }),
                 None => files
                     .iter()
-                    .map(|p| check_cached(c, &dispatch, p))
+                    .map(|p| check_cached(c, &dispatch, p, git))
                     .collect(),
             };
             let mut hits = Vec::new();
             let mut misses = Vec::new();
             for entry in checked {
                 match entry {
-                    Ok(report) => hits.push(report),
+                    Ok(hit) => {
+                        sig_refreshed |= hit.refreshed;
+                        hits.push((hit.report, Some(hit.sig)));
+                    }
                     Err(p) => misses.push(p),
                 }
             }
@@ -247,32 +274,38 @@ pub fn run() -> i32 {
         None => (Vec::new(), files.iter().collect()),
     };
 
-    let mut reports: Vec<FileReport> = match &pool {
+    // Analyze the misses, signing each off the bytes just read when a cache is
+    // in play (no cache, no hashing cost).
+    let want_sig = cache_path.is_some();
+    let mut entries: Vec<(FileReport, Option<cache::Sig>)> = match &pool {
         Some(pool) => pool.install(|| {
             to_analyze
                 .par_iter()
-                .filter_map(|p| read_and_analyze(&dispatch, p))
+                .filter_map(|p| read_and_analyze(&dispatch, p, want_sig))
                 .collect()
         }),
         None => to_analyze
             .iter()
-            .filter_map(|p| read_and_analyze(&dispatch, p))
+            .filter_map(|p| read_and_analyze(&dispatch, p, want_sig))
             .collect(),
     };
-    reports.extend(cached_reports);
+    entries.extend(cached_entries);
 
     // Refresh the cache — unless it is already exactly what we would write:
-    // every file was a hit AND the cache holds nothing else. The second check
-    // matters when files were deleted (or newly excluded) since the last run —
-    // all-hits alone would skip the write and leave their stale entries behind.
-    let cache_is_current = cache
-        .as_ref()
-        .is_some_and(|c| to_analyze.is_empty() && c.entry_count() == reports.len());
+    // every file was a stat hit AND the cache holds nothing else. The second
+    // check matters when files were deleted (or newly excluded) since the last
+    // run — all-hits alone would skip the write and leave their stale entries
+    // behind. A hit that passed by content hash also forces the write: its
+    // stored mtime is stale, and persisting the refreshed one is what lets the
+    // next run stat-hit instead of hashing again.
+    let cache_is_current = cache.as_ref().is_some_and(|c| {
+        to_analyze.is_empty() && !sig_refreshed && c.entry_count() == entries.len()
+    });
     if let Some(cache_file) = cache_path.as_deref()
         && !cache_is_current
     {
         let store = || {
-            cache::store(cache_file, &reports, &|p| {
+            cache::store(cache_file, &entries, &|p| {
                 lang_for(&dispatch, p).map(|l| l.name)
             })
         };
@@ -282,6 +315,7 @@ pub fn run() -> i32 {
         }
     }
 
+    let mut reports: Vec<FileReport> = entries.into_iter().map(|(r, _)| r).collect();
     reports.sort_by(|a, b| a.path.cmp(&b.path));
 
     // Determine exit status before any `--min` filtering, so display options do
@@ -390,13 +424,28 @@ fn split_exts(s: &str) -> Vec<String> {
 /// Read a file and analyze it with the language matching its extension,
 /// reporting (but not failing on) read errors. A file whose extension no active
 /// language claims is skipped silently (it was only collected via `--ext`).
+///
+/// With `want_sig`, also produce the file's cache signature, hashed from the
+/// bytes already in memory. The mtime is stat'ed *before* the read: if the
+/// file changes in between, the stored mtime undershoots the analyzed content,
+/// and the next run's hash check catches it — the unsafe direction (a fresher
+/// mtime masking older content) can't happen.
 fn read_and_analyze(
     dispatch: &HashMap<String, &'static lang::Language>,
     path: &Path,
-) -> Option<FileReport> {
+    want_sig: bool,
+) -> Option<(FileReport, Option<cache::Sig>)> {
     let language = lang_for(dispatch, path)?;
+    let mtime = if want_sig {
+        cache::mtime_ns(path)
+    } else {
+        None
+    };
     match std::fs::read_to_string(path) {
-        Ok(src) => Some((language.analyze)(path, &src)),
+        Ok(src) => {
+            let sig = mtime.map(|m| cache::sig_for(src.as_bytes(), m));
+            Some(((language.analyze)(path, &src), sig))
+        }
         Err(e) => {
             eprintln!("cccc: cannot read {}: {e}", path.display());
             None
@@ -415,14 +464,15 @@ fn lang_for(
         .copied()
 }
 
-/// The cached report for `path` — or `path` itself, as a miss to analyze.
+/// The cache hit for `path` — or `path` itself, as a miss to analyze.
 fn check_cached<'a>(
     cache: &cache::Cache,
     dispatch: &HashMap<String, &'static lang::Language>,
     path: &'a std::path::PathBuf,
-) -> Result<FileReport, &'a std::path::PathBuf> {
-    match lang_for(dispatch, path).and_then(|l| cache.lookup(path, l.name)) {
-        Some(report) => Ok(report),
+    git: Option<&cache::LazyGitIndex>,
+) -> Result<cache::Hit, &'a std::path::PathBuf> {
+    match lang_for(dispatch, path).and_then(|l| cache.lookup(path, l.name, git)) {
+        Some(hit) => Ok(hit),
         None => Err(path),
     }
 }

--- a/crates/cccc-cli/tests/cli.rs
+++ b/crates/cccc-cli/tests/cli.rs
@@ -818,6 +818,199 @@ fn cache_prunes_deleted_files() {
 }
 
 #[test]
+fn cache_survives_mtime_only_changes() {
+    let dir = std::env::temp_dir().join("cccc_cache_touch_cli_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("sample.ts");
+    std::fs::copy("tests/fixtures/sample.ts", &src).unwrap();
+    let cache = dir.join("cache.bin");
+
+    let run = || {
+        let out = Command::cargo_bin("cccc")
+            .unwrap()
+            .args(["--no-config", "--cache-file"])
+            .arg(&cache)
+            .arg(&dir)
+            .assert()
+            .success();
+        String::from_utf8(out.get_output().stdout.clone()).unwrap()
+    };
+    // Same bytes, new mtime — what a fresh checkout does to every file in CI.
+    let touch = |offset: u64| {
+        std::fs::File::options()
+            .write(true)
+            .open(&src)
+            .unwrap()
+            .set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(offset))
+            .unwrap();
+    };
+
+    let cold = run();
+    touch(10);
+    assert_eq!(run(), cold, "an mtime-only change must still hit");
+
+    // That hit went through the content hash; the run must persist the
+    // refreshed mtime so the next run is back to stat-only validation…
+    let rewritten = std::fs::read(&cache).unwrap();
+    let stable = run();
+    assert_eq!(stable, cold);
+    // …and an untouched all-hit run must take the skip-the-write fast path.
+    assert_eq!(
+        std::fs::read(&cache).unwrap(),
+        rewritten,
+        "an all-stat-hit run must not rewrite the cache"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn cache_git_index_skips_revalidation() {
+    let dir = std::env::temp_dir().join("cccc_cache_git_cli_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    // git resolves symlinks in --show-toplevel (macOS /tmp); agree with it.
+    let dir = dir.canonicalize().unwrap();
+    let src = dir.join("sample.ts");
+    std::fs::copy("tests/fixtures/sample.ts", &src).unwrap();
+    let git = |args: &[&str]| {
+        assert!(
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(&dir)
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success()
+        );
+    };
+    git(&["init", "-q"]);
+    git(&["add", "sample.ts"]);
+    git(&[
+        "-c",
+        "user.name=t",
+        "-c",
+        "user.email=t@t",
+        "commit",
+        "-q",
+        "-m",
+        "x",
+    ]);
+    let cache = dir.join("cache.bin");
+
+    let run = || {
+        let out = Command::cargo_bin("cccc")
+            .unwrap()
+            .args(["--no-config", "--cache-file"])
+            .arg(&cache)
+            .arg(&dir)
+            .assert()
+            .success();
+        String::from_utf8(out.get_output().stdout.clone()).unwrap()
+    };
+
+    let cold = run();
+    // Same bytes, new mtime — a fresh checkout. With a clean git index the
+    // entry is validated off the index's blob SHA (no re-read), the fresh
+    // mtime is persisted, and the following run is back to pure stat hits.
+    std::fs::File::options()
+        .write(true)
+        .open(&src)
+        .unwrap()
+        .set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(10))
+        .unwrap();
+    assert_eq!(run(), cold, "a git-vouched file must still hit");
+    let converged = std::fs::read(&cache).unwrap();
+    assert_eq!(run(), cold);
+    assert_eq!(
+        std::fs::read(&cache).unwrap(),
+        converged,
+        "once the mtime is persisted, an all-stat-hit run must not rewrite"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// End-to-end pin of the git-index path: after an mtime-only change, the run
+/// must produce the cold output even when the source file is unreadable.
+/// Neither the content-hash fallback nor re-analysis can open the file, so a
+/// successful, identical run proves the entry was validated off git's blob
+/// SHA alone — i.e. cccc's own blob-SHA computation agrees with git's.
+#[cfg(unix)]
+#[test]
+fn cache_git_index_validates_unreadable_file() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = std::env::temp_dir().join("cccc_cache_git_unreadable_cli_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    // git resolves symlinks in --show-toplevel (macOS /tmp); agree with it.
+    let dir = dir.canonicalize().unwrap();
+    let src = dir.join("sample.ts");
+    std::fs::copy("tests/fixtures/sample.ts", &src).unwrap();
+    let git = |args: &[&str]| {
+        assert!(
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(&dir)
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success()
+        );
+    };
+    git(&["init", "-q"]);
+    git(&["add", "sample.ts"]);
+    git(&[
+        "-c",
+        "user.name=t",
+        "-c",
+        "user.email=t@t",
+        "commit",
+        "-q",
+        "-m",
+        "x",
+    ]);
+    let cache = dir.join("cache.bin");
+
+    let run = || {
+        let out = Command::cargo_bin("cccc")
+            .unwrap()
+            .args(["--no-config", "--cache-file"])
+            .arg(&cache)
+            .arg(&dir)
+            .assert()
+            .success();
+        String::from_utf8(out.get_output().stdout.clone()).unwrap()
+    };
+
+    let cold = run();
+    // The CI shape: mtime moved (into the past — a future mtime trips git's
+    // racy-clean re-read), content untouched, index stat-clean.
+    std::fs::File::options()
+        .write(true)
+        .open(&src)
+        .unwrap()
+        .set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(3600))
+        .unwrap();
+    git(&["update-index", "--refresh"]);
+    let perms = std::fs::metadata(&src).unwrap().permissions();
+    std::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    assert_eq!(
+        run(),
+        cold,
+        "an unreadable, git-clean file must be served from the cache via the index"
+    );
+
+    std::fs::set_permissions(&src, perms).unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn no_cache_flag_disables_config_enabled_cache() {
     let dir = std::env::temp_dir().join("cccc_no_cache_cli_test");
     let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
The results cache validated entries by (size, mtime) alone, which breaks under mtime churn without content change — most importantly CI, where a fresh checkout stamps every file with clone time: a restored cache never hit, and measured runs came out slower than no cache at all (vscode 127.5ms vs 107.8ms cold), re-analyzing everything and rewriting the whole cache on top.

Each entry now stores size, mtime, and the SHA-1 git would name a blob of the content — computed by cccc from the bytes it analyzed, never taken on faith from git, so every check is content-to-content and it never matters which commit (or how stale a run) a restored cache came from. Validation is a cheapest-first chain:

1. **stat** — size+mtime match: trusted with no read. The local fast path, unchanged — and git is not even spawned for an all-stat-hit run (an eager-spawn draft cost 15–30ms of `git status` contention on big trees).
2. **git's index** — the mtime moved but git calls the file clean and the index's blob SHA matches the stored one: still no read. One `git ls-files -s`/`git status` pair answers for the whole tree. git is consulted lazily, only after some stat check has failed; under `CI=…` (set by every major CI service) the subprocesses start eagerly ahead of file discovery instead, hiding their latency entirely.
3. **the blob SHA re-derived from the bytes** — the final authority, for whatever git can't vouch: dirty/untracked files, non-git trees, filtered (CRLF-normalized, LFS) files, SHA-256 repositories, any git failure at all. Misses hash the bytes they were about to analyze anyway, so populating the cache costs no extra read.

A hit via step 2 or 3 persists its refreshed mtime, so churn converges to stat hits after one run. Stats are taken before reads, so a mid-run modification can only make the stored mtime undershoot the analyzed content —caught by the next run's re-hash, never masking newer content.

On the choice of hash: candidates were benchmarked at ~48 GB/s (xxh3-128), ~12 GB/s (hw CRC32), and ~1.3 GB/s (SHA-1), but the re-derive path is I/O-bound (~0.6–1.5 GB/s effective including opens), so even the slowest never reaches the wall clock — and the SHA-1 git already requires is the only candidate that also serves the index check. One content identity, one hash dependency (`sha1_smol`); SHA-1 here is the same non-adversarial, per-path content comparison git itself rests on, not a cryptographic boundary.

Measured on real monorepos (Apple M4 Pro, median of 5 after 1 warmup; method and full tables in BENCHMARK.md). "CI churn" is the state `actions/checkout` leaves behind — every mtime reset, stat-clean git index, `CI=true`:

| Corpus | cold | warm (stat) | CI churn, git | CI churn, hash only | local churn, git |
|--------|-----:|------------:|--------------:|--------------------:|-----------------:|
| vscode (TS/JS, 12,301 files) | 345.0 ms | 149.1 ms | **225.3 ms** | 399.9 ms | 259.6 ms |
| kubernetes (Go, 17,518) | 992.7 ms | 181.7 ms | **307.2 ms** | 651.6 ms | 364.2 ms |
| postgres (C, 2,954) | 525.3 ms | 33.6 ms | **56.2 ms** | 92.9 ms | 75.0 ms |

The cache goes from net-negative in CI to 1.5–9.3× faster than cold (persist the file with e.g. `actions/cache`; 1.7–2.1× faster than re-hashing the tree). Warm local runs measure identical with git present or absent, and output stays byte-for-byte identical to an uncached run in every scenario —verified on all three corpora before timing.
