### PR TITLE
Add --print-cache-file for tooling that wires cache persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ or an artifact store; `--pretty` prints the same document indented.
 | `--cache` | Cache results and reuse them for files unchanged since the last run |
 | `--cache-file PATH` | Where to keep the results cache (implies `--cache`). Default: `.cccc.cache` next to the config file, or in the current directory |
 | `--no-cache` | Do not use the results cache, even if the config file enables it |
+| `--print-cache-file` | Print the resolved cache path (nothing when disabled) and exit; for tooling |
 | `--pretty` | Pretty-print the JSON output (default is compact, one line) |
 | `-j, --jobs N` | Number of files to analyze in parallel (default: logical CPU count) |
 
@@ -261,7 +262,11 @@ measured 1.6–9.6× faster than a cold run (see BENCHMARK.md). Correctness
 never depends on which commit (or how stale a run) the restored cache came
 from: every entry is checked content-to-content. Under `CI=…` (GitHub
 Actions sets it) the git subprocesses start early so their latency hides
-behind file discovery. For example:
+behind file discovery.
+
+On GitHub Actions, [cccc-action](https://github.com/moznion/cccc-action)
+wires the persistence up for you when the config sets `cache = true`. Wiring
+it by hand looks like:
 
 ```yaml
 - uses: actions/cache@v4
@@ -271,6 +276,11 @@ behind file discovery. For example:
     restore-keys: cccc-
 - run: cccc --cache --max-cognitive 15 src/
 ```
+
+Tooling that needs the resolved cache location up front (the way
+cccc-action does) can ask `cccc --print-cache-file`, which prints the path
+the current config resolves to — or nothing when caching is disabled — and
+exits.
 
 ### Examples
 
@@ -320,6 +330,10 @@ A composite action to install and run `cccc`  in CI lives in its own repository:
   with:
     path: src/           # analyze this; thresholds come from cccc.toml
 ```
+
+Like thresholds, caching is driven by the config: when `cccc.toml` sets
+`cache = true`, the action persists the [results cache](#results-cache)
+across runs on its own (via `actions/cache` — no workflow wiring needed).
 
 An example GitHub Actions workflow for continuously measuring complexity with [k1LoW/octocov](https://github.com/k1LoW/octocov) is available at [.github/workflows/complexity.yml](./.github/workflows/complexity.yml).
 

--- a/crates/cccc-cli/src/cli.rs
+++ b/crates/cccc-cli/src/cli.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 #[command(about)]
 pub struct Cli {
     /// Files or directories to analyze.
-    #[arg(required = true)]
+    #[arg(required_unless_present = "print_cache_file")]
     pub paths: Vec<PathBuf>,
 
     /// Restrict analysis to these languages (comma-separated; e.g.
@@ -94,6 +94,12 @@ pub struct Cli {
     /// Do not use the results cache, even if the config file enables it.
     #[arg(long, conflicts_with_all = ["cache", "cache_file"])]
     pub no_cache: bool,
+
+    /// Print the resolved results-cache path and exit without analyzing
+    /// anything. Prints nothing when the cache is disabled. For tooling
+    /// (e.g. CI wrappers) that must know the cache location up front.
+    #[arg(long)]
+    pub print_cache_file: bool,
 
     /// Pretty-print the JSON output (the default is compact, one line).
     #[arg(long)]

--- a/crates/cccc-cli/src/lib.rs
+++ b/crates/cccc-cli/src/lib.rs
@@ -115,6 +115,16 @@ pub fn run() -> i32 {
                     .join(".cccc.cache")
             })
     });
+    // Tooling introspection: report where the cache would live (nothing when
+    // disabled) so wrappers like CI actions can wire persistence around it
+    // without re-implementing config discovery.
+    if cli.print_cache_file {
+        if let Some(path) = &cache_path {
+            println!("{}", path.display());
+        }
+        return 0;
+    }
+
     let max_cognitive = cli.max_cognitive.or(config.max_cognitive);
     let max_cyclomatic = cli.max_cyclomatic.or(config.max_cyclomatic);
     let min = cli.min.or(config.min);

--- a/crates/cccc-cli/tests/cli.rs
+++ b/crates/cccc-cli/tests/cli.rs
@@ -1011,6 +1011,54 @@ fn cache_git_index_validates_unreadable_file() {
 }
 
 #[test]
+fn print_cache_file_reports_the_resolved_path() {
+    let dir = std::env::temp_dir().join("cccc_print_cache_file_cli_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("cccc.toml"), "cache = true\n").unwrap();
+
+    // Config-enabled cache: the default file next to the config.
+    let out = Command::cargo_bin("cccc")
+        .unwrap()
+        .current_dir(&dir)
+        .args(["--print-cache-file"])
+        .assert()
+        .success();
+    let printed = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    let printed = printed.trim_end();
+    assert!(
+        std::path::Path::new(printed).is_absolute() && printed.ends_with("/.cccc.cache"),
+        "expected an absolute default path, got {printed:?}"
+    );
+
+    // An explicit --cache-file wins.
+    let out = Command::cargo_bin("cccc")
+        .unwrap()
+        .current_dir(&dir)
+        .args(["--print-cache-file", "--cache-file", "elsewhere.bin"])
+        .assert()
+        .success();
+    let printed = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    assert_eq!(printed.trim_end(), "elsewhere.bin");
+
+    // Disabled (--no-cache, or no config at all): prints nothing.
+    for args in [
+        vec!["--print-cache-file", "--no-cache"],
+        vec!["--print-cache-file", "--no-config"],
+    ] {
+        Command::cargo_bin("cccc")
+            .unwrap()
+            .current_dir(&dir)
+            .args(&args)
+            .assert()
+            .success()
+            .stdout(predicates::str::is_empty());
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn no_cache_flag_disables_config_enabled_cache() {
     let dir = std::env::temp_dir().join("cccc_no_cache_cli_test");
     let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
CI wrappers (e.g. cccc-action) that persist the results cache need its location before cccc runs — but that location is decided by config-file discovery (`.cccc.cache` beside the discovered config, or `cache-file`). Re-implementing that resolution outside cccc would drift.

`cccc --print-cache-file` prints the resolved cache path and exits, or prints nothing when caching is disabled, honoring the same precedence as a real run (--cache-file / --cache / --no-cache / config). Paths are not required with the flag, since nothing is analyzed.