### PR TITLE
Add cpp parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ dependencies = [
 name = "cccc-c"
 version = "1.6.0"
 dependencies = [
+ "cccc-clike",
  "cccc-core",
  "tree-sitter",
  "tree-sitter-c",
@@ -222,6 +223,7 @@ dependencies = [
  "cccc-c",
  "cccc-clojure",
  "cccc-core",
+ "cccc-cpp",
  "cccc-dart",
  "cccc-es",
  "cccc-go",
@@ -248,6 +250,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cccc-clike"
+version = "1.6.0"
+dependencies = [
+ "cccc-core",
+ "tree-sitter",
+]
+
+[[package]]
 name = "cccc-clojure"
 version = "1.6.0"
 dependencies = [
@@ -259,6 +269,16 @@ name = "cccc-core"
 version = "1.6.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cccc-cpp"
+version = "1.6.0"
+dependencies = [
+ "cccc-clike",
+ "cccc-core",
+ "tree-sitter",
+ "tree-sitter-cpp",
 ]
 
 [[package]]
@@ -1602,6 +1622,16 @@ name = "tree-sitter-c"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ members = [
     "crates/cccc-kt",
     "crates/cccc-py",
     "crates/cccc-zig",
+    "crates/cccc-clike",
     "crates/cccc-c",
+    "crates/cccc-cpp",
     "crates/cccc-pl",
     "crates/cccc-swift",
     "crates/cccc-java",
@@ -44,7 +46,9 @@ cccc-lisp = { path = "crates/cccc-lisp", version = "1.6.0" }
 cccc-kt = { path = "crates/cccc-kt", version = "1.6.0" }
 cccc-py = { path = "crates/cccc-py", version = "1.6.0" }
 cccc-zig = { path = "crates/cccc-zig", version = "1.6.0" }
+cccc-clike = { path = "crates/cccc-clike", version = "1.6.0" }
 cccc-c = { path = "crates/cccc-c", version = "1.6.0" }
+cccc-cpp = { path = "crates/cccc-cpp", version = "1.6.0" }
 cccc-pl = { path = "crates/cccc-pl", version = "1.6.0" }
 cccc-swift = { path = "crates/cccc-swift", version = "1.6.0" }
 cccc-java = { path = "crates/cccc-java", version = "1.6.0" }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@
   - **C** (`--lang c`), via the official
     [tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c) grammar.
     Analyzes `.c`, `.h`.
+  - **C++** (`--lang cpp`, aliases `c++`/`cxx`), via the official
+    [tree-sitter-cpp](https://github.com/tree-sitter/tree-sitter-cpp) grammar.
+    Analyzes `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx`, `.h++`, `.tpp`, `.ipp`
+    (`.h` is claimed by C, since extension routing needs disjoint claims —
+    override via `--ext`). Shares its lowering for everything C and C++ have
+    in common with `cccc-c`, via `cccc-clike`.
   - **Perl** (`--lang perl`), via the community-maintained
     [tree-sitter-perl](https://github.com/tree-sitter-perl/tree-sitter-perl)
     grammar. Analyzes `.pl`, `.pm`, `.t`.
@@ -73,6 +79,8 @@ library and extended to other languages:
 | [`cccc-py`](crates/cccc-py) | Python adapter **library**: lowers the official [tree-sitter-python](https://github.com/tree-sitter/tree-sitter-python) CST into `cccc-core`'s IR. Depends only on `cccc-core` + tree-sitter + the Python grammar — **no CLI dependencies**. Like `cccc-kt`, the grammar's C source is compiled by `cc`, so building needs a C compiler (no libclang). |
 | [`cccc-zig`](crates/cccc-zig) | Zig adapter **library**: lowers the pure-Rust [zigsyn](https://docs.rs/zigsyn) AST into `cccc-core`'s IR. Depends only on `cccc-core` + zigsyn — **no CLI dependencies or C toolchain**. |
 | [`cccc-c`](crates/cccc-c) | C adapter **library**: lowers the official [tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c) CST into `cccc-core`'s IR. Depends only on `cccc-core` + tree-sitter + the C grammar — **no CLI dependencies**. Like `cccc-kt`/`cccc-py`, the grammar's C source is compiled by `cc`, so building needs a C compiler (no libclang). |
+| [`cccc-clike`](crates/cccc-clike) | Shared **lowering** for the C-family adapters: `tree-sitter-cpp`'s grammar is a superset of `tree-sitter-c`'s, so `cccc-c` and `cccc-cpp` both construct a `cccc_clike::SharedBuilder` (tagged `Language::C`/`Language::Cpp`) instead of duplicating the lowering for what they share (functions, `if`, loops, `switch`, jumps, logical folding, preprocessor conditionals, calls). C++-only constructs (lambdas, `catch`, range-`for`) are gated on the language tag in the same `visit`. Depends only on `cccc-core` + tree-sitter — no grammar crate, no CLI dependencies. |
+| [`cccc-cpp`](crates/cccc-cpp) | C++ adapter **library**: lowers the official [tree-sitter-cpp](https://github.com/tree-sitter/tree-sitter-cpp) CST into `cccc-core`'s IR via `cccc-clike`. Depends only on `cccc-core` + `cccc-clike` + tree-sitter + the C++ grammar — **no CLI dependencies**. |
 | [`cccc-pl`](crates/cccc-pl) | Perl adapter **library**: lowers the [tree-sitter-perl](https://github.com/tree-sitter-perl/tree-sitter-perl) CST into `cccc-core`'s IR. Depends only on `cccc-core` + tree-sitter + the Perl grammar — **no CLI dependencies**. Like `cccc-kt`/`cccc-py`, the grammar's C source is compiled by `cc`, so building needs a C compiler (no libclang). |
 | [`cccc-swift`](crates/cccc-swift) | Swift adapter **library**: lowers the [alex-pinkus/tree-sitter-swift](https://github.com/alex-pinkus/tree-sitter-swift) CST into `cccc-core`'s IR. Depends only on `cccc-core` + tree-sitter + the Swift grammar — **no CLI dependencies**. Like `cccc-kt`/`cccc-py`, the grammar's C source is compiled by `cc`, so building needs a C compiler (no libclang). |
 | [`cccc-java`](crates/cccc-java) | Java adapter **library**: lowers the official [tree-sitter-java](https://github.com/tree-sitter/tree-sitter-java) CST into `cccc-core`'s IR. Depends only on `cccc-core` + tree-sitter + the Java grammar — **no CLI dependencies**. Like `cccc-kt`/`cccc-py`, the grammar's C source is compiled by `cc`, so building needs a C compiler (no libclang). |
@@ -88,10 +96,11 @@ To support another language: (1) add an adapter crate that lowers its AST into
 it with one entry in `cccc-cli`'s `lang::LANGUAGES` (and add the dependency) —
 no new binary, and no reimplementing the metrics or the CLI. `cccc-es` (oxc),
 `cccc-rs` (syn), `cccc-go` (gosyn), `cccc-php` (php-rs-parser), `cccc-rb`
-(ruby-prism), `cccc-kt` / `cccc-py` / `cccc-pl` (tree-sitter), `cccc-swift` (tree-sitter), `cccc-c` (tree-sitter),
+(ruby-prism), `cccc-kt` / `cccc-py` / `cccc-pl` (tree-sitter), `cccc-swift` (tree-sitter), `cccc-c` / `cccc-cpp` (tree-sitter),
 `cccc-java` (tree-sitter), `cccc-dart` (tree-sitter), `cccc-scheme` (lispexp), `cccc-clojure` (lispexp), `cccc-lisp` (lispexp, Common Lisp / Emacs Lisp / …),
 and `cccc-zig` (zigsyn) are the reference adapters: same shape, different parser.
-The Lisp-family adapters share their lowering skeleton via `cccc-lisp-kit`.
+The Lisp-family adapters share their lowering skeleton via `cccc-lisp-kit`;
+`cccc-c` and `cccc-cpp` share theirs via `cccc-clike`.
 
 **See [docs/ADDING_A_LANGUAGE.md](docs/ADDING_A_LANGUAGE.md) for the full
 step-by-step guide**, including the IR-node reference table, the
@@ -532,7 +541,21 @@ C has no exceptions and no `??`; `#define` bodies are opaque to the grammar, so
 code inside a macro body is not scored. One known wart of preprocessor-unaware
 parsing: the standard `extern "C" {` guard splits its braces across two
 `#ifdef __cplusplus` blocks, which surfaces as a parse warning — the rest of
-the header still parses and scores.
+the header still parses and scores. Another: the `<cinttypes>` printf-width
+macros (`"..." PRIu32 "..."` and friends) only become adjacent string
+literals after macro expansion, which the grammar never performs, so they
+also surface as a parse warning local to that expression.
+
+For **C++** (`--lang cpp`): everything above for C applies unchanged (`tree-sitter-cpp`'s
+grammar is a superset of `tree-sitter-c`'s, sharing the same node kinds/fields
+for what the two languages have in common), plus: a `[...](...){...}` lambda is
+its own function-like unit (like a closure elsewhere); `catch` clauses map to
+the corresponding node (the `try` body runs at the surrounding level, same as
+Kotlin/Python's `catch`/`except`); range-`for` (`for (auto &x : xs)`) is a loop,
+same as any other. Constructor/destructor/operator-overload names, including
+out-of-line qualified definitions (`Foo::bar`), are dug out of the declarator
+chain; a qualified definition and a qualified or unqualified self-call both
+resolve to the same trailing simple name, so recursion is still detected.
 
 For **Perl** (`--lang perl`): named `sub`s / `method` declarations (feature
 `class`, Perl 5.38+) / anonymous `sub`s are the function-like units, and a

--- a/crates/cccc-c/src/lib.rs
+++ b/crates/cccc-c/src/lib.rs
@@ -12,12 +12,14 @@
 //! the engine cares about and emits the matching IR nodes. All complexity rules
 //! live in [`cccc_core::engine`].
 //!
-//! Like `cccc-kt`, lowering is an explicit `kind()`-dispatch whose **default arm
-//! recurses into every named child** (see the warning in
-//! `docs/ADDING_A_LANGUAGE.md`), so an unrecognized construct is transparent and
-//! nothing nested inside it is silently dropped. The IR tree is assembled with a
-//! stack of "collectors": [`Builder::collect`] pushes a fresh child vector, runs
-//! a sub-traversal, and pops the nodes it gathered.
+//! Most of the actual lowering (functions, `if`, loops, `switch`, jumps,
+//! logical-operator folding, preprocessor conditionals, calls) is shared with
+//! `cccc-cpp` and lives in `cccc_clike::SharedBuilder`, since `tree-sitter-cpp`'s
+//! grammar is a superset of this one. This crate just loads the C grammar and
+//! wraps that shared builder (see [`Builder`]); [`Builder::visit`] recurses
+//! into every named child by default (see the warning in
+//! `docs/ADDING_A_LANGUAGE.md`), so an unrecognized construct is transparent
+//! and nothing nested inside it is silently dropped.
 //!
 //! ## C-to-IR mapping notes
 //!
@@ -47,14 +49,15 @@
 
 use std::path::Path;
 
+use cccc_clike::{SharedBuilder, collect_errors};
 use cccc_core::engine;
-use cccc_core::ir::{LogicalOp, Node, SwitchCase};
+use cccc_core::ir::Node;
 use cccc_core::report::FileReport;
 use tree_sitter::Node as TsNode;
 
 /// File extensions analyzed by default (when `--ext` is not given). `.h`
-/// headers are claimed as C — this project bundles no C++ front-end, so there
-/// is no dispatch ambiguity.
+/// headers are claimed as C — `cccc-cpp` deliberately doesn't claim `.h`
+/// (extension routing needs disjoint claims), so there's no ambiguity.
 pub const DEFAULT_EXTS: &[&str] = &["c", "h"];
 
 /// Parse `source` and produce its [`FileReport`], scoring via the core engine.
@@ -90,348 +93,24 @@ pub fn to_ir(_path: &Path, source: &str) -> (Vec<Node>, Vec<String>) {
     (builder.finish(), errors)
 }
 
-/// Collect the 1-based lines of every `ERROR`/`MISSING` node so a partially
-/// parsed file surfaces its syntax problems (deduplicated, order preserved).
-fn collect_errors(node: TsNode, out: &mut Vec<String>) {
-    let mut cursor = node.walk();
-    if node.is_error() || node.is_missing() {
-        let msg = format!("syntax error at line {}", node.start_position().row + 1);
-        if !out.contains(&msg) {
-            out.push(msg);
-        }
-    }
-    for child in node.children(&mut cursor) {
-        collect_errors(child, out);
-    }
-}
-
 /// Assembles the IR tree while an explicit recursion walks the tree-sitter CST.
-struct Builder<'a> {
-    /// Source bytes, for extracting identifier text.
-    src: &'a [u8],
-    /// Stack of node collectors. `stack.last_mut()` receives emitted nodes;
-    /// structural nodes push a fresh collector for their body, then pop it.
-    stack: Vec<Vec<Node>>,
-}
+struct Builder<'a>(SharedBuilder<'a>);
 
 impl<'a> Builder<'a> {
     fn new(src: &'a [u8]) -> Self {
-        Self {
-            src,
-            stack: vec![Vec::new()], // module-level collector
-        }
+        Self(SharedBuilder::new(src, cccc_clike::Language::C))
     }
 
     /// The module-level node list (the single remaining collector).
-    fn finish(mut self) -> Vec<Node> {
-        self.stack.pop().expect("module collector")
-    }
-
-    /// Append a node to the current collector.
-    fn emit(&mut self, node: Node) {
-        self.stack.last_mut().expect("collector").push(node);
-    }
-
-    /// Run `f` against a fresh collector and return the nodes it gathered.
-    fn collect<F: FnOnce(&mut Self)>(&mut self, f: F) -> Vec<Node> {
-        self.stack.push(Vec::new());
-        f(self);
-        self.stack.pop().expect("collector")
-    }
-
-    /// The UTF-8 text of `node`, or `""` if it is not valid UTF-8.
-    fn text(&self, node: TsNode) -> &str {
-        node.utf8_text(self.src).unwrap_or("")
-    }
-
-    /// Recurse into every named child of `node` (skipping `extras`, i.e.
-    /// comments — see [`named_children`]). This is the "transparent" step shared
-    /// by every arm that carries no score of its own: a fresh cursor walk with
-    /// no intermediate `Vec` allocation.
-    fn visit_named_children(&mut self, node: TsNode) {
-        let mut cursor = node.walk();
-        for child in node.named_children(&mut cursor) {
-            if !child.is_extra() {
-                self.visit(child);
-            }
-        }
+    fn finish(self) -> Vec<Node> {
+        self.0.finish()
     }
 
     // ---- traversal --------------------------------------------------------
 
     fn visit(&mut self, node: TsNode) {
-        match node.kind() {
-            "function_definition" => {
-                let name = node
-                    .child_by_field_name("declarator")
-                    .and_then(|d| declarator_name(self, d))
-                    .unwrap_or_else(|| "<function>".into());
-                let line = node.start_position().row as u32 + 1;
-                let body = self.collect(|b| b.visit_named_children(node));
-                self.emit(Node::Function {
-                    name,
-                    kind: "function".to_string(),
-                    line,
-                    body,
-                });
-            }
-
-            "if_statement" => {
-                let branch = self.lower_if(node);
-                self.emit(branch);
-            }
-            "conditional_expression" => {
-                let field = |name| node.child_by_field_name(name);
-                let test =
-                    field("condition").map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
-                let then =
-                    field("consequence").map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
-                let alternate =
-                    field("alternative").map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
-                self.emit(Node::Conditional {
-                    test,
-                    then,
-                    alternate,
-                });
-            }
-            "for_statement" | "while_statement" | "do_statement" => {
-                let body = self.collect(|b| b.visit_named_children(node));
-                self.emit(Node::Loop { body });
-            }
-            "switch_statement" => self.visit_switch(node),
-
-            "break_statement" | "continue_statement" => self.emit(Node::Jump { labeled: false }),
-            "goto_statement" => self.emit(Node::Jump { labeled: true }),
-
-            "binary_expression" => match logical_op_of(node) {
-                Some(op) => self.visit_logical(node, op),
-                None => self.visit_named_children(node),
-            },
-
-            "call_expression" => self.visit_call(node),
-
-            // The grammar aliases preprocessor conditionals inside declarations
-            // and inside blocks to the same kinds, so one set of arms covers
-            // both placements.
-            "preproc_if" | "preproc_ifdef" => {
-                let branch = self.lower_preproc(node);
-                self.emit(branch);
-            }
-
-            // Everything else is transparent: recurse into every named child so
-            // no nested construct is missed.
-            _ => self.visit_named_children(node),
-        }
+        self.0.visit(node);
     }
-
-    /// Build a `Branch` from an `if_statement` (recursively, so an `else if`
-    /// becomes a nested `Branch` and thus scores flat). The grammar tags the
-    /// parts with fields (`condition`, `consequence`, `alternative`), so we
-    /// address them by field rather than by position.
-    fn lower_if(&mut self, node: TsNode) -> Node {
-        let field = |name| node.child_by_field_name(name);
-        let test = field("condition").map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
-        let then = field("consequence").map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
-        let alternate = field("alternative").map(|ec| Box::new(self.lower_else(ec)));
-        Node::Branch {
-            test,
-            then,
-            alternate,
-        }
-    }
-
-    /// Lower an `else_clause`. If it wraps a single `if_statement` it is an
-    /// `else if` → nested `Branch`; otherwise it is a plain `else` → `Group`.
-    fn lower_else(&mut self, else_clause: TsNode) -> Node {
-        let inner = named_children(else_clause);
-        if let [only] = inner.as_slice()
-            && only.kind() == "if_statement"
-        {
-            return self.lower_if(*only);
-        }
-        Node::Group(self.collect(|b| b.visit_named_children(else_clause)))
-    }
-
-    /// Build a `Branch` from a preprocessor conditional (`#if` / `#ifdef` /
-    /// `#ifndef` / `#elif` / `#elifdef` / `#elifndef`): the directive's own
-    /// body is the `then`, and the `alternative` field chains — an `#elif`
-    /// nests as another `Branch` (scoring flat, like `else if`), an `#else`
-    /// closes the chain as a `Group`.
-    fn lower_preproc(&mut self, node: TsNode) -> Node {
-        // `#if`/`#elif` carry a `condition` expression; `#ifdef`/`#elifdef`
-        // carry a `name` identifier. Either way it is the branch's test.
-        let cond = node
-            .child_by_field_name("condition")
-            .or_else(|| node.child_by_field_name("name"));
-        let alt = node.child_by_field_name("alternative");
-        let test = cond.map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
-        let then = self.collect(|b| {
-            for child in named_children(node) {
-                let is_cond = cond.is_some_and(|c| c.id() == child.id());
-                let is_alt = alt.is_some_and(|a| a.id() == child.id());
-                if !is_cond && !is_alt {
-                    b.visit(child);
-                }
-            }
-        });
-        let alternate = alt.map(|a| {
-            Box::new(match a.kind() {
-                "preproc_elif" | "preproc_elifdef" | "preproc_elifndef" => self.lower_preproc(a),
-                // preproc_else
-                _ => Node::Group(self.collect(|b| b.visit_named_children(a))),
-            })
-        });
-        Node::Branch {
-            test,
-            then,
-            alternate,
-        }
-    }
-
-    /// A `switch` becomes a `Switch`: one `SwitchCase` per `case_statement`,
-    /// with the `default:` label marked `is_default` (the grammar gives it no
-    /// `value` field). The subject expression runs at the switch's own level.
-    fn visit_switch(&mut self, node: TsNode) {
-        if let Some(cond) = node.child_by_field_name("condition") {
-            self.visit(cond);
-        }
-        let mut cases = Vec::new();
-        if let Some(body) = node.child_by_field_name("body") {
-            for child in named_children(body) {
-                if child.kind() == "case_statement" {
-                    let is_default = child.child_by_field_name("value").is_none();
-                    let case_body = self.collect(|b| b.visit_named_children(child));
-                    cases.push(SwitchCase {
-                        is_default,
-                        body: case_body,
-                    });
-                } else {
-                    // A label or statement outside any case (legal C) runs at
-                    // the switch's level.
-                    self.visit(child);
-                }
-            }
-        }
-        self.emit(Node::Switch { cases });
-    }
-
-    /// One folded [`Node::Logical`] for a run of like operators (`&&` / `||`).
-    /// A different operator nested inside starts a fresh `Logical`.
-    fn visit_logical(&mut self, node: TsNode, op: LogicalOp) {
-        let mut operands = Vec::new();
-        for side in named_children(node) {
-            self.collect_logical_side(side, op, &mut operands);
-        }
-        self.emit(Node::Logical { op, operands });
-    }
-
-    /// Flatten same-operator operands; a different operator nests as its own
-    /// `Logical`; any other expression becomes a `Group` of its sub-nodes.
-    fn collect_logical_side(&mut self, side: TsNode, op: LogicalOp, operands: &mut Vec<Node>) {
-        let side = unwrap_parens(side);
-        match logical_op_of(side) {
-            Some(side_op) => {
-                let kids = named_children(side);
-                if side_op == op {
-                    for k in kids {
-                        self.collect_logical_side(k, op, operands);
-                    }
-                } else {
-                    let mut sub = Vec::new();
-                    for k in kids {
-                        self.collect_logical_side(k, side_op, &mut sub);
-                    }
-                    operands.push(Node::Logical {
-                        op: side_op,
-                        operands: sub,
-                    });
-                }
-            }
-            None => operands.push(Node::Group(self.collect(|b| b.visit(side)))),
-        }
-    }
-
-    /// Emit a `Call` (with the callee's simple name for recursion detection),
-    /// then recurse into the callee expression and the argument list (which may
-    /// contain further constructs).
-    fn visit_call(&mut self, node: TsNode) {
-        let callee = node
-            .child_by_field_name("function")
-            .and_then(|f| self.callee_name(f));
-        self.emit(Node::Call { callee });
-        self.visit_named_children(node);
-    }
-
-    /// Simple name of a directly-called callee: `foo(..)`, `s.foo(..)` /
-    /// `p->foo(..)`, or a parenthesized/dereferenced function pointer
-    /// (`(*fp)(..)`). Returns the trailing identifier.
-    fn callee_name(&self, node: TsNode) -> Option<String> {
-        match node.kind() {
-            "identifier" => Some(self.text(node).to_string()),
-            "field_expression" => node
-                .child_by_field_name("field")
-                .map(|f| self.text(f).to_string()),
-            "parenthesized_expression" | "pointer_expression" => named_children(node)
-                .into_iter()
-                .find_map(|c| self.callee_name(c)),
-            _ => None,
-        }
-    }
-}
-
-/// Dig the defined name out of a declarator chain: a `function_definition`'s
-/// `declarator` may wrap the identifier in `pointer_declarator` (functions
-/// returning pointers), `function_declarator`, and `parenthesized_declarator`
-/// layers (`int *(*f(void))(int)`). Follows `declarator` fields, falling back
-/// to the named children for the field-less `parenthesized_declarator`.
-fn declarator_name(b: &Builder, node: TsNode) -> Option<String> {
-    match node.kind() {
-        "identifier" => Some(b.text(node).to_string()),
-        "parenthesized_declarator" => named_children(node)
-            .into_iter()
-            .find_map(|c| declarator_name(b, c)),
-        _ => node
-            .child_by_field_name("declarator")
-            .and_then(|d| declarator_name(b, d)),
-    }
-}
-
-/// The named children of `node` (skipping `extras`), collected into a `Vec` so
-/// the caller can index or slice-match them without holding the cursor's
-/// borrow. Comments are `extras` in this grammar: they can appear *between*
-/// any two children, so dropping them keeps slice-shape checks
-/// (`lower_else`'s single-child `else if` test, `unwrap_parens`' single-child
-/// unwrap) honest.
-fn named_children(node: TsNode) -> Vec<TsNode> {
-    let mut cursor = node.walk();
-    node.named_children(&mut cursor)
-        .filter(|c| !c.is_extra())
-        .collect()
-}
-
-/// The normalized logical operator a node represents, if any. The grammar
-/// aliases the preprocessor's binary expressions to `binary_expression` too,
-/// so `#if defined(A) && defined(B)` folds the same way.
-fn logical_op_of(node: TsNode) -> Option<LogicalOp> {
-    if node.kind() != "binary_expression" {
-        return None;
-    }
-    match node.child_by_field_name("operator")?.kind() {
-        "&&" => Some(LogicalOp::And),
-        "||" => Some(LogicalOp::Or),
-        _ => None,
-    }
-}
-
-/// Follow a single-child `parenthesized_expression` to the inner expression so
-/// `a && (b && c)` folds into one run.
-fn unwrap_parens(node: TsNode) -> TsNode {
-    if node.kind() == "parenthesized_expression"
-        && let [inner] = named_children(node).as_slice()
-    {
-        return unwrap_parens(*inner);
-    }
-    node
 }
 
 #[cfg(test)]

--- a/crates/cccc-cli/Cargo.toml
+++ b/crates/cccc-cli/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "The unified cccc binary: one CLI that measures cognitive/cyclomatic complexity across every bundled language (ECMAScript/TypeScript, Rust, Go, PHP, Ruby, Kotlin, Python, Perl, Zig, C, Swift, Java, Dart)"
+description = "The unified cccc binary: one CLI that measures cognitive/cyclomatic complexity across every bundled language (ECMAScript/TypeScript, Rust, Go, PHP, Ruby, Kotlin, Python, Perl, Zig, C, C++, Swift, Java, Dart)"
 
 [[bin]]
 name = "cccc"
@@ -26,6 +26,7 @@ cccc-kt = { workspace = true }
 cccc-py = { workspace = true }
 cccc-zig = { workspace = true }
 cccc-c = { workspace = true }
+cccc-cpp = { workspace = true }
 cccc-pl = { workspace = true }
 cccc-swift = { workspace = true }
 cccc-java = { workspace = true }

--- a/crates/cccc-cli/src/lang.rs
+++ b/crates/cccc-cli/src/lang.rs
@@ -113,6 +113,12 @@ pub const LANGUAGES: &[Language] = &[
         analyze: cccc_c::analyze_source,
     },
     Language {
+        name: "cpp",
+        aliases: &["c++", "cxx"],
+        exts: cccc_cpp::DEFAULT_EXTS,
+        analyze: cccc_cpp::analyze_source,
+    },
+    Language {
         name: "perl",
         aliases: &["pl"],
         exts: cccc_pl::DEFAULT_EXTS,
@@ -297,6 +303,7 @@ mod tests {
                 "python".to_string(),
                 "zig".to_string(),
                 "c".to_string(),
+                "cpp".to_string(),
                 "perl".to_string(),
                 "swift".to_string(),
                 "java".to_string(),

--- a/crates/cccc-cli/tests/cli.rs
+++ b/crates/cccc-cli/tests/cli.rs
@@ -342,7 +342,7 @@ fn analyzes_all_languages_in_one_run() {
     // The fixtures dir holds one file per language; a single run dispatches each
     // by extension and reports them all together.
     let v = json(&["tests/fixtures"]);
-    assert_eq!(v["summary"]["file_count"], 17);
+    assert_eq!(v["summary"]["file_count"], 18);
     let paths: Vec<String> = v["files"]
         .as_array()
         .unwrap()
@@ -363,6 +363,7 @@ fn analyzes_all_languages_in_one_run() {
         "sample.py",
         "sample.zig",
         "sample.c",
+        "sample.cpp",
         "sample.pl",
         "sample.swift",
         "sample.java",
@@ -402,7 +403,7 @@ fn exclude_lang_drops_a_language() {
     // Excluding every language except ES and Rust leaves the .ts and .rs fixtures.
     let v = json(&[
         "--exclude-lang",
-        "go,php,ruby,scheme,commonlisp,emacslisp,clojure,kotlin,python,perl,zig,c,swift,java,dart",
+        "go,php,ruby,scheme,commonlisp,emacslisp,clojure,kotlin,python,perl,zig,c,cpp,swift,java,dart",
         "tests/fixtures",
     ]);
     let mut exts: Vec<String> = v["files"]
@@ -448,7 +449,7 @@ fn excluding_every_language_is_an_error() {
         .unwrap()
         .args([
             "--exclude-lang",
-            "es,rust,go,php,ruby,scheme,commonlisp,emacslisp,clojure,kotlin,python,perl,zig,c,swift,java,dart",
+            "es,rust,go,php,ruby,scheme,commonlisp,emacslisp,clojure,kotlin,python,perl,zig,c,cpp,swift,java,dart",
             "tests/fixtures",
         ])
         .assert()

--- a/crates/cccc-cli/tests/fixtures/sample.cpp
+++ b/crates/cccc-cli/tests/fixtures/sample.cpp
@@ -1,0 +1,16 @@
+class Sample {
+public:
+    unsigned int sumOfPrimes(unsigned int max) {
+        unsigned int total = 0;
+        for (unsigned int i = 2; i <= max; i++) {
+            for (unsigned int j = 2; j < i; j++) {
+                if (i % j == 0) {
+                    goto next;
+                }
+            }
+            total += i;
+next:;
+        }
+        return total;
+    }
+};

--- a/crates/cccc-cli/tests/lang_smoke.rs
+++ b/crates/cccc-cli/tests/lang_smoke.rs
@@ -96,6 +96,11 @@ fn c_fixture_dispatches() {
 }
 
 #[test]
+fn cpp_fixture_dispatches() {
+    assert_sum_of_primes("sample.cpp", "sumOfPrimes");
+}
+
+#[test]
 fn perl_fixture_dispatches() {
     assert_sum_of_primes("sample.pl", "sum_of_primes");
 }

--- a/crates/cccc-clike/Cargo.toml
+++ b/crates/cccc-clike/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
-name = "cccc-c"
+name = "cccc-clike"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "C (tree-sitter) adapter that lowers source into the cccc-core complexity IR"
+description = "Shared tree-sitter lowering helpers for C-family adapters (cccc-c, cccc-cpp), factored out because tree-sitter-cpp's grammar is a superset of tree-sitter-c's"
 
 [dependencies]
 cccc-core = { workspace = true }
-cccc-clike = { workspace = true }
 tree-sitter = "0.26"
-tree-sitter-c = "0.24"

--- a/crates/cccc-clike/src/lib.rs
+++ b/crates/cccc-clike/src/lib.rs
@@ -1,0 +1,422 @@
+//! Shared lowering code for the C-family adapters (`cccc-c` and `cccc-cpp`).
+//!
+//! C and C++ share a lot of syntax. The `tree-sitter-cpp` grammar is a
+//! superset of `tree-sitter-c`'s, so constructs like `if`, loops, `switch`,
+//! `break`/`continue`/`goto`, `&&`/`||`, preprocessor conditionals, and
+//! function calls parse to the same node kinds in both languages. This crate
+//! lowers all of that once, instead of duplicating it in both adapter crates.
+//!
+//! The main type is [`SharedBuilder`]. Each adapter creates one and tells it
+//! which language it's lowering (see [`Language`]). Most of
+//! [`SharedBuilder::visit`] handles the constructs C and C++ share. A few
+//! match arms handle constructs that only exist in C++ (lambdas, `catch`,
+//! range-`for`, and extra ways of naming a function such as destructors,
+//! operators, and qualified names like `Foo::bar`) — those arms just check
+//! the language field before running.
+//!
+//! This crate has no scoring logic; that lives in `cccc_core::engine`. It
+//! depends only on `cccc-core` and `tree-sitter`, not on a specific grammar
+//! crate. Each adapter crate brings its own grammar dependency
+//! (`tree-sitter-c` or `tree-sitter-cpp`) and does its own parsing.
+
+use cccc_core::ir::{LogicalOp, Node, SwitchCase};
+use tree_sitter::Node as TsNode;
+
+/// Collect the 1-based lines of every `ERROR`/`MISSING` node so a partially
+/// parsed file surfaces its syntax problems (deduplicated, order preserved).
+pub fn collect_errors(node: TsNode, out: &mut Vec<String>) {
+    let mut cursor = node.walk();
+    if node.is_error() || node.is_missing() {
+        let msg = format!("syntax error at line {}", node.start_position().row + 1);
+        if !out.contains(&msg) {
+            out.push(msg);
+        }
+    }
+    for child in node.children(&mut cursor) {
+        collect_errors(child, out);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Language {
+    C,
+    Cpp,
+}
+
+#[derive(Debug)]
+pub struct SharedBuilder<'a> {
+    src: &'a [u8],
+    stack: Vec<Vec<Node>>,
+    lang: Language,
+}
+
+impl SharedBuilder<'_> {
+    pub fn new(src: &[u8], lang: Language) -> SharedBuilder<'_> {
+        SharedBuilder {
+            src,
+            stack: vec![Vec::new()],
+            lang,
+        }
+    }
+
+    pub fn lang(&self) -> &Language {
+        &self.lang
+    }
+
+    /// The module-level node list (the single remaining collector).
+    pub fn finish(mut self) -> Vec<Node> {
+        self.stack.pop().expect("module collector")
+    }
+
+    /// Run `f` against a fresh collector and return the nodes it gathered.
+    pub fn collect<F: FnOnce(&mut Self)>(&mut self, f: F) -> Vec<Node> {
+        self.stack.push(Vec::new());
+        f(self);
+        self.stack.pop().expect("collector")
+    }
+
+    /// Append a node to the current collector.
+    pub fn emit(&mut self, node: Node) {
+        self.stack.last_mut().expect("collector").push(node);
+    }
+
+    /// The UTF-8 text of `node`, or `""` if it is not valid UTF-8.
+    pub fn text(&self, node: TsNode) -> &str {
+        node.utf8_text(self.src).unwrap_or("")
+    }
+
+    /// Recurse into every named child of `node` (skipping `extras`, i.e.
+    /// comments — see [`named_children`]). This is the "transparent" step shared
+    /// by every arm that carries no score of its own: a fresh cursor walk with
+    /// no intermediate `Vec` allocation.
+    pub fn visit_named_children(&mut self, node: TsNode) {
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if !child.is_extra() {
+                self.visit(child);
+            }
+        }
+    }
+
+    // ---- traversal --------------------------------------------------------
+
+    pub fn visit(&mut self, node: TsNode) {
+        match node.kind() {
+            "function_definition" => {
+                let name = node
+                    .child_by_field_name("declarator")
+                    .and_then(|d| declarator_name(self, d))
+                    .unwrap_or_else(|| "<function>".into());
+                self.emit_function_node(name, "function", node);
+            }
+            // C++ only: a `[...](...){...}` closure is its own scored unit,
+            // same as a named function.
+            "lambda_expression" if self.lang == Language::Cpp => {
+                self.emit_function_node("<lambda>".into(), "lambda", node)
+            }
+
+            "if_statement" => {
+                let branch = self.lower_if(node);
+                self.emit(branch);
+            }
+            "conditional_expression" => {
+                let field = |name| node.child_by_field_name(name);
+                let test =
+                    field("condition").map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
+                let then =
+                    field("consequence").map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
+                let alternate =
+                    field("alternative").map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
+                self.emit(Node::Conditional {
+                    test,
+                    then,
+                    alternate,
+                });
+            }
+            "for_statement" | "while_statement" | "do_statement" => self.emit_loop(node),
+            // C++ only: `for (auto &x : xs)`.
+            "for_range_loop" if self.lang == Language::Cpp => self.emit_loop(node),
+            "switch_statement" => self.visit_switch(node),
+
+            "break_statement" | "continue_statement" => self.emit(Node::Jump { labeled: false }),
+            "goto_statement" => self.emit(Node::Jump { labeled: true }),
+
+            "binary_expression" => match logical_op_of(node) {
+                Some(op) => self.visit_logical(node, op),
+                None => self.visit_named_children(node),
+            },
+
+            "call_expression" => self.visit_call(node),
+
+            // C++ only: the `try` body runs at the surrounding level (it's
+            // visited transparently by the fallback arm below); each `catch`
+            // clause is its own `Node::Catch` decision point.
+            "catch_clause" if self.lang == Language::Cpp => {
+                let body = self.collect(|b| b.visit_named_children(node));
+                self.emit(Node::Catch { body });
+            }
+
+            // The grammar aliases preprocessor conditionals inside declarations
+            // and inside blocks to the same kinds, so one set of arms covers
+            // both placements.
+            "preproc_if" | "preproc_ifdef" => {
+                let branch = self.lower_preproc(node);
+                self.emit(branch);
+            }
+
+            // Everything else is transparent: recurse into every named child so
+            // no nested construct is missed.
+            _ => self.visit_named_children(node),
+        }
+    }
+
+    /// A function-like unit: emit a `Function` whose body walks *all* named
+    /// children (so a lambda hiding in a default parameter value is still
+    /// reached), scored in its own frame.
+    fn emit_function_node(&mut self, name: String, kind: &'static str, node: TsNode) {
+        let line = node.start_position().row as u32 + 1;
+        let body = self.collect(|b| b.visit_named_children(node));
+        self.emit(Node::Function {
+            name,
+            kind: kind.to_string(),
+            line,
+            body,
+        });
+    }
+
+    /// Any loop (`for` / `while` / `do`-`while`, or C++'s range-`for`): +1 at
+    /// its own nesting level, body walked transparently.
+    fn emit_loop(&mut self, node: TsNode) {
+        let body = self.collect(|b| b.visit_named_children(node));
+        self.emit(Node::Loop { body });
+    }
+
+    /// Build a `Branch` from an `if_statement` (recursively, so an `else if`
+    /// becomes a nested `Branch` and thus scores flat). The grammar tags the
+    /// parts with fields (`condition`, `consequence`, `alternative`), so we
+    /// address them by field rather than by position.
+    fn lower_if(&mut self, node: TsNode) -> Node {
+        let field = |name| node.child_by_field_name(name);
+        let test = field("condition").map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
+        let then = field("consequence").map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
+        let alternate = field("alternative").map(|ec| Box::new(self.lower_else(ec)));
+        Node::Branch {
+            test,
+            then,
+            alternate,
+        }
+    }
+
+    /// Lower an `else_clause`. If it wraps a single `if_statement` it is an
+    /// `else if` → nested `Branch`; otherwise it is a plain `else` → `Group`.
+    fn lower_else(&mut self, else_clause: TsNode) -> Node {
+        let inner = named_children(else_clause);
+        if let [only] = inner.as_slice()
+            && only.kind() == "if_statement"
+        {
+            return self.lower_if(*only);
+        }
+        Node::Group(self.collect(|b| b.visit_named_children(else_clause)))
+    }
+
+    /// Build a `Branch` from a preprocessor conditional (`#if` / `#ifdef` /
+    /// `#ifndef` / `#elif` / `#elifdef` / `#elifndef`): the directive's own
+    /// body is the `then`, and the `alternative` field chains — an `#elif`
+    /// nests as another `Branch` (scoring flat, like `else if`), an `#else`
+    /// closes the chain as a `Group`.
+    fn lower_preproc(&mut self, node: TsNode) -> Node {
+        // `#if`/`#elif` carry a `condition` expression; `#ifdef`/`#elifdef`
+        // carry a `name` identifier. Either way it is the branch's test.
+        let cond = node
+            .child_by_field_name("condition")
+            .or_else(|| node.child_by_field_name("name"));
+        let alt = node.child_by_field_name("alternative");
+        let test = cond.map_or_else(Vec::new, |c| self.collect(|b| b.visit(c)));
+        let then = self.collect(|b| {
+            for child in named_children(node) {
+                let is_cond = cond.is_some_and(|c| c.id() == child.id());
+                let is_alt = alt.is_some_and(|a| a.id() == child.id());
+                if !is_cond && !is_alt {
+                    b.visit(child);
+                }
+            }
+        });
+        let alternate = alt.map(|a| {
+            Box::new(match a.kind() {
+                "preproc_elif" | "preproc_elifdef" | "preproc_elifndef" => self.lower_preproc(a),
+                // preproc_else
+                _ => Node::Group(self.collect(|b| b.visit_named_children(a))),
+            })
+        });
+        Node::Branch {
+            test,
+            then,
+            alternate,
+        }
+    }
+
+    /// A `switch` becomes a `Switch`: one `SwitchCase` per `case_statement`,
+    /// with the `default:` label marked `is_default` (the grammar gives it no
+    /// `value` field). The subject expression runs at the switch's own level.
+    fn visit_switch(&mut self, node: TsNode) {
+        if let Some(cond) = node.child_by_field_name("condition") {
+            self.visit(cond);
+        }
+        let mut cases = Vec::new();
+        if let Some(body) = node.child_by_field_name("body") {
+            for child in named_children(body) {
+                if child.kind() == "case_statement" {
+                    let is_default = child.child_by_field_name("value").is_none();
+                    let case_body = self.collect(|b| b.visit_named_children(child));
+                    cases.push(SwitchCase {
+                        is_default,
+                        body: case_body,
+                    });
+                } else {
+                    // A label or statement outside any case (legal in both
+                    // C and C++) runs at the switch's level.
+                    self.visit(child);
+                }
+            }
+        }
+        self.emit(Node::Switch { cases });
+    }
+
+    /// One folded [`Node::Logical`] for a run of like operators (`&&` / `||`).
+    /// A different operator nested inside starts a fresh `Logical`.
+    fn visit_logical(&mut self, node: TsNode, op: LogicalOp) {
+        let mut operands = Vec::new();
+        for side in named_children(node) {
+            self.collect_logical_side(side, op, &mut operands);
+        }
+        self.emit(Node::Logical { op, operands });
+    }
+
+    /// Flatten same-operator operands; a different operator nests as its own
+    /// `Logical`; any other expression becomes a `Group` of its sub-nodes.
+    fn collect_logical_side(&mut self, side: TsNode, op: LogicalOp, operands: &mut Vec<Node>) {
+        let side = unwrap_parens(side);
+        match logical_op_of(side) {
+            Some(side_op) => {
+                let kids = named_children(side);
+                if side_op == op {
+                    for k in kids {
+                        self.collect_logical_side(k, op, operands);
+                    }
+                } else {
+                    let mut sub = Vec::new();
+                    for k in kids {
+                        self.collect_logical_side(k, side_op, &mut sub);
+                    }
+                    operands.push(Node::Logical {
+                        op: side_op,
+                        operands: sub,
+                    });
+                }
+            }
+            None => operands.push(Node::Group(self.collect(|b| b.visit(side)))),
+        }
+    }
+
+    /// Emit a `Call` (with the callee's simple name for recursion detection),
+    /// then recurse into the callee expression and the argument list (which may
+    /// contain further constructs).
+    fn visit_call(&mut self, node: TsNode) {
+        let callee = node
+            .child_by_field_name("function")
+            .and_then(|f| self.callee_name(f));
+        self.emit(Node::Call { callee });
+        self.visit_named_children(node);
+    }
+
+    /// Simple name of a directly-called callee: `foo(..)`, `s.foo(..)` /
+    /// `p->foo(..)`, or a parenthesized/dereferenced function pointer
+    /// (`(*fp)(..)`) — plus, in C++, a qualified call (`Foo::bar(..)`).
+    /// Returns the trailing identifier.
+    fn callee_name(&self, node: TsNode) -> Option<String> {
+        match node.kind() {
+            "identifier" => Some(self.text(node).to_string()),
+            "field_expression" => node
+                .child_by_field_name("field")
+                .map(|f| self.text(f).to_string()),
+            "qualified_identifier" if self.lang == Language::Cpp => node
+                .child_by_field_name("name")
+                .and_then(|n| self.callee_name(n)),
+            "parenthesized_expression" | "pointer_expression" => named_children(node)
+                .into_iter()
+                .find_map(|c| self.callee_name(c)),
+            _ => None,
+        }
+    }
+}
+
+/// Find the name being defined in a declarator chain.
+///
+/// A `function_definition`'s `declarator` is rarely just a plain identifier.
+/// In C, it can be wrapped in a `pointer_declarator` (a function returning a
+/// pointer), a `function_declarator`, or a `parenthesized_declarator`
+/// (`int *(*f(void))(int)` still names `f`). In C++, the name itself can also
+/// be a `field_identifier` (a method defined inline in a class body), a
+/// `destructor_name` (`~Foo`), an `operator_name` (`operator+`), or a
+/// `qualified_identifier` (`Foo::bar`, an out-of-line definition) — those four
+/// only happen in C++, so they're gated on `b.lang`.
+///
+/// For a `qualified_identifier` we keep only the trailing name (`Foo::bar`
+/// becomes `bar`), because that's what [`SharedBuilder::callee_name`] returns
+/// for a qualified *call* too. Without that, an out-of-line method calling
+/// itself wouldn't be recognized as recursion.
+fn declarator_name(b: &SharedBuilder, node: TsNode) -> Option<String> {
+    match node.kind() {
+        "identifier" => Some(b.text(node).to_string()),
+        "field_identifier" | "destructor_name" | "operator_name" if b.lang == Language::Cpp => {
+            Some(b.text(node).to_string())
+        }
+        "qualified_identifier" if b.lang == Language::Cpp => node
+            .child_by_field_name("name")
+            .and_then(|n| declarator_name(b, n)),
+        "parenthesized_declarator" => named_children(node)
+            .into_iter()
+            .find_map(|c| declarator_name(b, c)),
+        _ => node
+            .child_by_field_name("declarator")
+            .and_then(|d| declarator_name(b, d)),
+    }
+}
+
+/// The named children of `node` (skipping `extras`), collected into a `Vec` so
+/// the caller can index or slice-match them without holding the cursor's
+/// borrow. Comments are `extras` in this grammar: they can appear *between*
+/// any two children, so dropping them keeps slice-shape checks
+/// (`lower_else`'s single-child `else if` test, `unwrap_parens`' single-child
+/// unwrap) honest.
+fn named_children(node: TsNode) -> Vec<TsNode> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .filter(|c| !c.is_extra())
+        .collect()
+}
+
+/// The normalized logical operator a node represents, if any. The grammar
+/// aliases the preprocessor's binary expressions to `binary_expression` too,
+/// so `#if defined(A) && defined(B)` folds the same way.
+fn logical_op_of(node: TsNode) -> Option<LogicalOp> {
+    if node.kind() != "binary_expression" {
+        return None;
+    }
+    match node.child_by_field_name("operator")?.kind() {
+        "&&" => Some(LogicalOp::And),
+        "||" => Some(LogicalOp::Or),
+        _ => None,
+    }
+}
+
+/// Follow a single-child `parenthesized_expression` to the inner expression so
+/// `a && (b && c)` folds into one run.
+fn unwrap_parens(node: TsNode) -> TsNode {
+    if node.kind() == "parenthesized_expression"
+        && let [inner] = named_children(node).as_slice()
+    {
+        return unwrap_parens(*inner);
+    }
+    node
+}

--- a/crates/cccc-cpp/Cargo.toml
+++ b/crates/cccc-cpp/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "cccc-c"
+name = "cccc-cpp"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "C (tree-sitter) adapter that lowers source into the cccc-core complexity IR"
+description = "C++ (tree-sitter) adapter that lowers source into the cccc-core complexity IR"
 
 [dependencies]
 cccc-core = { workspace = true }
 cccc-clike = { workspace = true }
 tree-sitter = "0.26"
-tree-sitter-c = "0.24"
+tree-sitter-cpp = "0.23.4"

--- a/crates/cccc-cpp/src/lib.rs
+++ b/crates/cccc-cpp/src/lib.rs
@@ -1,0 +1,501 @@
+//! C++ adapter: parses source with the official [tree-sitter] `tree-sitter-cpp`
+//! grammar and lowers the concrete syntax tree into the language-agnostic
+//! [`cccc_core::ir`].
+//!
+//! This is a pure library — it depends only on `cccc-core`, `tree-sitter`, and
+//! the C++ grammar, with no CLI machinery. The unified `cccc` binary (the
+//! `cccc-cli` crate) registers this adapter's [`analyze_source`]/[`DEFAULT_EXTS`]
+//! and dispatches C++ files to it.
+//!
+//! This crate contains **no scoring logic** — it only recognizes the constructs
+//! the engine cares about and emits the matching IR nodes. All complexity rules
+//! live in [`cccc_core::engine`].
+//!
+//! Everything C and C++ share (functions, `if`, the ternary, loops, `switch`,
+//! jumps, logical-operator folding, preprocessor conditionals, calls) is
+//! lowered by `cccc_clike::SharedBuilder`, tagged with `Language::Cpp`; see
+//! `crates/cccc-clike/src/lib.rs`. This crate supplies only the grammar
+//! loading and the extension list. The C++-only constructs are lowered there
+//! too (gated on the language tag), not here:
+//!
+//! - a `[...](...){...}` lambda → [`Node::Function`] (`"<lambda>"`, kind
+//!   `"lambda"`), its own scored unit.
+//! - `catch` clauses → [`Node::Catch`]; the `try` body runs at the
+//!   surrounding level.
+//! - range-`for` (`for (auto &x : xs)`) → [`Node::Loop`], same as any other
+//!   loop.
+//! - method/constructor/destructor/operator names, including out-of-line
+//!   qualified definitions (`Foo::bar`), are dug out of the declarator chain
+//!   the same way a C function name is.
+
+use std::path::Path;
+
+use cccc_clike::{SharedBuilder, collect_errors};
+use cccc_core::engine;
+use cccc_core::ir::Node;
+use cccc_core::report::FileReport;
+use tree_sitter::Node as TsNode;
+
+/// File extensions analyzed by default (when `--ext` is not given). `.h` is
+/// deliberately excluded: `cccc-c` already claims it, and extension dispatch
+/// requires disjoint claims. Users with C++ in `.h` files can override via
+/// `--ext`/the `[ext]` config.
+pub const DEFAULT_EXTS: &[&str] = &["cpp", "cc", "cxx", "hpp", "hxx", "h++", "tpp", "ipp"];
+
+/// Parse `source` and produce its [`FileReport`], scoring via the core engine.
+/// This is the convenience entry point used by the CLI; for the raw IR (e.g. to
+/// feed a different consumer) use [`to_ir`].
+pub fn analyze_source(path: &Path, source: &str) -> FileReport {
+    let (nodes, parse_errors) = to_ir(path, source);
+    engine::analyze(&path.display().to_string(), &nodes, parse_errors)
+}
+
+/// Parse `source` and lower it to the complexity IR, returning the module-level
+/// nodes plus any syntax-error messages. tree-sitter always yields a tree (it
+/// recovers from errors by inserting `ERROR`/`MISSING` nodes), so we still lower
+/// what parsed and report the error locations alongside.
+pub fn to_ir(_path: &Path, source: &str) -> (Vec<Node>, Vec<String>) {
+    let mut parser = tree_sitter::Parser::new();
+    if parser
+        .set_language(&tree_sitter_cpp::LANGUAGE.into())
+        .is_err()
+    {
+        return (Vec::new(), vec!["failed to load C++ grammar".to_string()]);
+    }
+    let Some(tree) = parser.parse(source, None) else {
+        return (Vec::new(), vec!["failed to parse C++ source".to_string()]);
+    };
+
+    let src = source.as_bytes();
+    let mut errors = Vec::new();
+    collect_errors(tree.root_node(), &mut errors);
+
+    let mut builder = Builder::new(src);
+    builder.visit(tree.root_node());
+    (builder.finish(), errors)
+}
+
+/// Assembles the IR tree while an explicit recursion walks the tree-sitter CST.
+struct Builder<'a>(SharedBuilder<'a>);
+
+impl<'a> Builder<'a> {
+    fn new(src: &'a [u8]) -> Self {
+        Self(SharedBuilder::new(src, cccc_clike::Language::Cpp))
+    }
+
+    /// The module-level node list (the single remaining collector).
+    fn finish(self) -> Vec<Node> {
+        self.0.finish()
+    }
+
+    // ---- traversal --------------------------------------------------------
+
+    fn visit(&mut self, node: TsNode) {
+        self.0.visit(node);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cccc_core::report::FunctionReport;
+
+    fn analyze(src: &str) -> FileReport {
+        analyze_source(Path::new("test.cpp"), src)
+    }
+
+    /// Parse once and assert the source came through clean. Almost every test
+    /// below wants this, so `cognitive_of`/`cyclomatic_of` route through it —
+    /// a stray parse error now fails the test that hit it, not just the
+    /// handful of tests that check `parse_errors` explicitly.
+    fn analyze_ok(src: &str) -> FileReport {
+        let report = analyze(src);
+        assert!(
+            report.parse_errors.is_empty(),
+            "unexpected parse errors: {:?}",
+            report.parse_errors
+        );
+        report
+    }
+
+    fn find<'a>(fns: &'a [FunctionReport], name: &str) -> Option<&'a FunctionReport> {
+        for f in fns {
+            if f.name == name {
+                return Some(f);
+            }
+            if let Some(found) = find(&f.children, name) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn cognitive_of(src: &str, name: &str) -> u32 {
+        cognitive_of_report(&analyze_ok(src), name)
+    }
+
+    fn cognitive_of_report(report: &FileReport, name: &str) -> u32 {
+        find(&report.functions, name)
+            .unwrap_or_else(|| panic!("function {name} not found"))
+            .cognitive
+    }
+
+    fn cyclomatic_of_report(report: &FileReport, name: &str) -> u32 {
+        find(&report.functions, name)
+            .unwrap_or_else(|| panic!("function {name} not found"))
+            .cyclomatic
+    }
+
+    #[test]
+    fn parses_without_error() {
+        let src = r#"
+            int add(int a, int b) {
+                return a + b;
+            }
+        "#;
+        analyze_ok(src);
+    }
+
+    #[test]
+    fn parse_error_is_reported() {
+        let errors = to_ir(
+            Path::new("t.cpp"),
+            "int ok(int a) { return a; }\nint bad( {\n",
+        )
+        .1;
+        assert!(!errors.is_empty());
+    }
+
+    #[test]
+    fn shared_c_constructs_still_score() {
+        // Same shape as cccc-c's `sonar_get_words_is_1`: proof the shared
+        // `cccc_clike` lowering is actually wired up, not just parsing.
+        let src = r#"
+            const char *get_words(int n) {
+                switch (n) {
+                    case 1:
+                        return "one";
+                    case 2:
+                        return "a couple";
+                    default:
+                        return "lots";
+                }
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "get_words"), 1);
+    }
+
+    #[test]
+    fn lambda_is_its_own_unit() {
+        let src = r#"
+            void host() {
+                auto f = [](int x) { if (x) { if (x) { } } };
+            }
+        "#;
+        let report = analyze_ok(src);
+        // host owns no structural complexity; the lambda does: +1 +2
+        assert_eq!(cognitive_of_report(&report, "host"), 0);
+        assert_eq!(cognitive_of_report(&report, "<lambda>"), 3);
+        assert_eq!(find(&report.functions, "<lambda>").unwrap().kind, "lambda");
+    }
+
+    #[test]
+    fn lambda_in_default_argument_is_reached() {
+        let src = r#"
+            void host(int key = [](int x) { return x ? 1 : 0; }()) {
+            }
+        "#;
+        assert_eq!(cognitive_of(src, "<lambda>"), 1);
+    }
+
+    #[test]
+    fn range_for_counts_as_loop() {
+        let src = r#"
+            void f(int a) {
+                for (auto &x : items) {
+                    if (a) { }
+                }
+            }
+        "#;
+        // range-for(+1) + nested if(+2) = 3
+        assert_eq!(cognitive_of(src, "f"), 3);
+    }
+
+    #[test]
+    fn catch_clause_counts_try_body_is_flat() {
+        let src = r#"
+            void f() {
+                try {
+                    if (true) { }
+                } catch (const std::exception &e) {
+                    if (true) { }
+                }
+            }
+        "#;
+        // try body runs at the surrounding level: if(+1).
+        // catch clause(+1) + nested if inside catch(+2) = 3.
+        // total = 1 + 3 = 4
+        assert_eq!(cognitive_of(src, "f"), 4);
+    }
+
+    #[test]
+    fn out_of_line_qualified_method_is_named() {
+        let src = r#"
+            class Foo {
+                void bar(int retry);
+            };
+            void Foo::bar(int retry) {
+                if (retry) {
+                    Foo::bar(0);
+                }
+            }
+        "#;
+        // an out-of-line definition is registered under its trailing simple
+        // name ("bar", not "Foo::bar") so it lines up with a qualified *call*
+        // to the same method, which resolves the same way: if(+1) +
+        // recursion(+1) = 2
+        assert_eq!(cognitive_of(src, "bar"), 2);
+    }
+
+    #[test]
+    fn out_of_line_method_unqualified_self_call_is_recursion() {
+        let src = r#"
+            class Foo {
+                void bar(int retry);
+            };
+            void Foo::bar(int retry) {
+                if (retry) {
+                    bar(0);
+                }
+            }
+        "#;
+        // the far more common case: calling the method unqualified from
+        // inside itself must still resolve to the same registered name.
+        assert_eq!(cognitive_of(src, "bar"), 2);
+    }
+
+    #[test]
+    fn destructor_is_named() {
+        let src = r#"
+            class Foo {
+                ~Foo() {
+                    if (true) { }
+                }
+            };
+        "#;
+        assert_eq!(cognitive_of(src, "~Foo"), 1);
+    }
+
+    #[test]
+    fn operator_overload_is_named() {
+        let src = r#"
+            class Foo {
+                Foo operator+(const Foo &other) {
+                    if (true) { }
+                    return *this;
+                }
+            };
+        "#;
+        assert_eq!(cognitive_of(src, "operator+"), 1);
+    }
+
+    #[test]
+    fn preproc_around_functions_still_finds_them() {
+        let src = r#"
+            #if defined(A) && defined(B)
+            int f(int x) {
+                if (x) { return 1; }
+                return 0;
+            }
+            #endif
+        "#;
+        assert_eq!(cognitive_of(src, "f"), 1);
+    }
+
+    #[test]
+    fn header_only_class_methods_score_independently() {
+        // A class defined entirely inline (as it would be in a header):
+        // constructor/destructor with member-initializer lists, a default
+        // member initializer, and one method calling another by a different
+        // name (not recursion). Every method is its own unit; the class body
+        // itself adds no complexity. Cross-checked against `lizard`, an
+        // independent C++ CCN tool: Stack::Stack=1, Stack::~Stack=1,
+        // Stack::empty=1, Stack::push=2, Stack::pop=2, Stack::grow=1.
+        let src = r#"
+            class Stack {
+            public:
+                Stack() : top_(0) {}
+                ~Stack() {}
+
+                bool empty() const {
+                    return top_ == 0;
+                }
+
+                void push(int x) {
+                    if (top_ >= capacity_) {
+                        grow();
+                    }
+                    data_[top_++] = x;
+                }
+
+                int pop() {
+                    if (empty()) {
+                        return -1;
+                    }
+                    return data_[--top_];
+                }
+
+            private:
+                void grow() {
+                    capacity_ *= 2;
+                }
+
+                int data_[1024];
+                int top_;
+                int capacity_ = 1024;
+            };
+        "#;
+        let report = analyze_ok(src);
+        assert_eq!(cognitive_of_report(&report, "Stack"), 0);
+        assert_eq!(cyclomatic_of_report(&report, "Stack"), 1);
+        assert_eq!(cognitive_of_report(&report, "~Stack"), 0);
+        assert_eq!(cyclomatic_of_report(&report, "~Stack"), 1);
+        assert_eq!(cognitive_of_report(&report, "empty"), 0);
+        assert_eq!(cyclomatic_of_report(&report, "empty"), 1);
+        assert_eq!(cognitive_of_report(&report, "push"), 1);
+        assert_eq!(cyclomatic_of_report(&report, "push"), 2);
+        assert_eq!(cognitive_of_report(&report, "pop"), 1);
+        assert_eq!(cyclomatic_of_report(&report, "pop"), 2);
+        assert_eq!(cognitive_of_report(&report, "grow"), 0);
+        assert_eq!(cyclomatic_of_report(&report, "grow"), 1);
+        // the class body/access specifiers add nothing of their own
+        assert_eq!(report.cognitive, 2);
+    }
+
+    #[test]
+    fn higher_complexity_combination() {
+        // A kitchen sink: switch, range-for containing a lambda (its own
+        // scored unit) with a folded `&&`, recursion, a labelled `goto`, and
+        // a preprocessor conditional — all in one function, at varying
+        // nesting depths. Cross-checked against `lizard`: it can't split the
+        // lambda into its own unit (a known limitation, not a contradiction),
+        // but its merged cyclomatic count for the whole snippet (7, or 6
+        // with the `#ifdef` block removed) equals ours once accounted for:
+        // `lizard` counts one base for the merged blob where we count one
+        // base per function (process=6 + lambda=2, minus the one duplicate
+        // base = 7; and 5 + 2 - 1 = 6 without the preprocessor block).
+        let src = r#"
+            int process(int n, std::vector<int> &items) {
+                switch (n % 3) {
+                    case 0:
+                        for (auto &x : items) {
+                            auto scored = [](int v) {
+                                return v > 0 && v < 10;
+                            };
+                            if (scored(x)) {
+                                break;
+                            }
+                        }
+                        break;
+                    case 1:
+                        return process(n - 1, items);
+                    default:
+                        goto done;
+                }
+            #ifdef DEBUG
+                log_debug(n);
+            #endif
+            done:
+                return n;
+            }
+        "#;
+        let report = analyze_ok(src);
+        // switch(+1) + [case0: for(+1+1=2) + if(+1+2=3)] + [case1: recursion
+        // (+1 flat)] + [default: goto (+1 flat)] + preproc(+1) = 9
+        assert_eq!(cognitive_of_report(&report, "process"), 9);
+        // base(1) + case0(1) + for-range(1) + if(1) + case1(1) + preproc(1)
+        // = 6 (default doesn't count; recursion/goto aren't cyclomatic)
+        assert_eq!(cyclomatic_of_report(&report, "process"), 6);
+        // the lambda scores fully independently: base 1 + && (+1) = 2,
+        // cognitive: && fold is flat = 1
+        assert_eq!(cognitive_of_report(&report, "<lambda>"), 1);
+        assert_eq!(cyclomatic_of_report(&report, "<lambda>"), 2);
+    }
+
+    #[test]
+    fn test_templated_header() {
+        let src = r#"
+            template <typename T>
+            Queue<T>::~Queue() {
+              if (this->data != nullptr) delete[] this->data;
+            }
+            "#;
+
+        let report = analyze_ok(src);
+        assert_eq!(cognitive_of_report(&report, "~Queue"), 1);
+    }
+
+    #[test]
+    fn test_treesitter_grammar_ambiguity() {
+        // This grammar is ambiguous: the parser has problems resolving
+        // the paranthesized expresion after the delete.
+        let src = r#"
+            template <typename T>
+            Queue<T>::~Queue() {
+              if (this->data != nullptr) delete[] (this->data);
+            }
+            "#;
+
+        let file_report = analyze(src);
+        assert_eq!(file_report.parse_errors.len(), 1);
+        assert_eq!(cognitive_of_report(&file_report, "~Queue"), 1);
+    }
+
+    #[test]
+    fn printf_format_macro_reports_error() {
+        // `"..." PRIu32 "..."` (the <cinttypes> printf-width-macro idiom) is
+        // another tree-sitter-cpp grammar gap: the grammar's
+        // concatenated_string rule expects only string-literal pieces, and
+        // an identifier that only becomes a string literal after macro
+        // expansion — expansion the grammar never performs — comes through
+        // as an ERROR nested inside it. The error stays local to that
+        // expression — the surrounding function still lowers and scores
+        // fine.
+        let src = r#"
+            void log_uptime(uint32_t up_time) {
+                if (up_time) {
+                    log_info("Uptime: %" PRIu32 "\r\n", up_time);
+                }
+            }
+            "#;
+
+        let report = analyze(src);
+        assert_eq!(report.parse_errors.len(), 1);
+        assert_eq!(cognitive_of_report(&report, "log_uptime"), 1);
+    }
+
+    #[test]
+    fn explicit_template_instantiation_reports_error() {
+        // `template class Foo<T>;` (explicit instantiation, no declarator)
+        // this is another tree-sitter-cpp grammar gap: the grammar parses `class Foo<T>` as a
+        // class_specifier and then expects a trailing declarator before the `;` (the same
+        // shape as `struct Foo x;`), which this syntax never has. The error
+        // stays local to that line — the templated class above it still
+        // lowers and scores fine.
+        let src = r#"
+            template <typename T>
+            class PeriodicTaskBase {
+            public:
+                void run(T ticks) {
+                    if (ticks) { }
+                }
+            };
+
+            template class PeriodicTaskBase<uint16_t>;
+            "#;
+
+        let report = analyze(src);
+        assert_eq!(report.parse_errors.len(), 1);
+        assert_eq!(cognitive_of_report(&report, "run"), 1);
+    }
+}


### PR DESCRIPTION
- Current implementation will not claim .h files to avoid ambiguity. So currently, scanning mixed C/C++ language projects require that header files have distinct names.. which is probably a good idea anyway? 